### PR TITLE
Starting to refactor clientcomm

### DIFF
--- a/Razor/Core/Main.cs
+++ b/Razor/Core/Main.cs
@@ -49,24 +49,7 @@ namespace Assistant
             {
                 if (m_ClientVersion == null || m_ClientVersion.Major < 2)
                 {
-                    string[] split = ClientCommunication.GetUOVersion().Split('.');
-
-                    if (split.Length < 3)
-                        return new Version(4, 0, 0, 0);
-
-                    int rev = 0;
-
-                    if (split.Length > 3)
-                        rev = Utility.ToInt32(split[3], 0);
-
-                    m_ClientVersion = new Version(
-                        Utility.ToInt32(split[0], 0),
-                        Utility.ToInt32(split[1], 0),
-                        Utility.ToInt32(split[2], 0),
-                        rev);
-
-                    if (m_ClientVersion.Major == 0) // sanity check if the client returns 0.0.0.0
-                        m_ClientVersion = new Version(4, 0, 0, 0);
+                    m_ClientVersion = ClientCommunication.Instance.GetUOVersion();
                 }
 
                 return m_ClientVersion;
@@ -232,6 +215,7 @@ namespace Assistant
         [STAThread]
         public static void Main(string[] Args)
         {
+            ClientCommunication.Init( true );
             Application.EnableVisualStyles();
             m_Running = true;
             Thread.CurrentThread.Name = "Razor Main Thread";

--- a/Razor/Core/PasswordMemory.cs
+++ b/Razor/Core/PasswordMemory.cs
@@ -23,7 +23,7 @@ namespace Assistant
 		{
 			byte[] buff = ASCIIEncoding.ASCII.GetBytes( source );
 			int kidx = 0;
-			string key = ClientCommunication.GetWindowsUserName();
+			string key = NativeMethods.GetWindowsUserName();
 			if ( key == String.Empty )
 				return String.Empty;
 			StringBuilder sb = new StringBuilder( source.Length * 2 + 2 );
@@ -44,7 +44,7 @@ namespace Assistant
 			if ( source.Length > 2 && source[0] == '1' && source[1] == '+' )
 			{
 				buff = new byte[(source.Length-2)/2];
-				string key = ClientCommunication.GetWindowsUserName();
+				string key = NativeMethods.GetWindowsUserName();
 				if ( key == String.Empty )
 					return String.Empty;
 				int kidx = 0;

--- a/Razor/Core/ScreenCapture.cs
+++ b/Razor/Core/ScreenCapture.cs
@@ -69,7 +69,7 @@ namespace Assistant
 			
 			try
 			{
-				IntPtr hBmp = ClientCommunication.CaptureScreen( ClientCommunication.FindUOWindow(), Config.GetBool( "CapFullScreen" ), timestamp );
+				IntPtr hBmp = NativeMethods.CaptureScreen( ClientCommunication.FindUOWindow(), Config.GetBool( "CapFullScreen" ), timestamp );
 				using ( Image img = Image.FromHbitmap( hBmp ) )
 					img.Save( filename, GetFormat( type ) );
 				DeleteObject( hBmp );

--- a/Razor/Macros/Actions.cs
+++ b/Razor/Macros/Actions.cs
@@ -1834,8 +1834,6 @@ namespace Assistant.Macros
 
         private static uint WM_KEYDOWN = 0x100, WM_KEYUP = 0x101;
 
-        [DllImport("user32.dll")]
-        private static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
         public static DateTime LastWalkTime { get { return m_LastWalk; } set { m_LastWalk = value; } }
 
@@ -1909,7 +1907,7 @@ namespace Assistant.Macros
                         break;
                 }
               
-                SendMessage(ClientCommunication.FindUOWindow(), WM_KEYDOWN, (IntPtr)direction, (IntPtr)1);
+                NativeMethods.SendMessage( ClientCommunication.FindUOWindow(), WM_KEYDOWN, (IntPtr)direction, (IntPtr)1);
 
                 return false;
             }

--- a/Razor/Map/MapWindow.cs
+++ b/Razor/Map/MapWindow.cs
@@ -128,7 +128,7 @@ namespace Assistant.MapUO
 					{
 						Engine.MainWindow.MapWindow.Hide();
 						Engine.MainWindow.BringToFront();
-						ClientCommunication.BringToFront( ClientCommunication.FindUOWindow() );
+						NativeMethods.BringToFront( ClientCommunication.FindUOWindow() );
 					}
 					else
 					{
@@ -340,7 +340,7 @@ namespace Assistant.MapUO
 				e.Cancel = true;
 				this.Hide();
 				Engine.MainWindow.BringToFront();
-				ClientCommunication.BringToFront( ClientCommunication.FindUOWindow() );
+				NativeMethods.BringToFront( ClientCommunication.FindUOWindow() );
 			}
 		}
 

--- a/Razor/NativeMethods.cs
+++ b/Razor/NativeMethods.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Assistant
+{
+    internal static unsafe class NativeMethods
+    {
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern int InstallLibrary( IntPtr thisWnd, int procid, int features );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern void Shutdown( bool closeClient );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern IntPtr FindUOWindow();
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern IntPtr GetSharedAddress();
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern IntPtr GetCommMutex();
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern uint TotalIn();
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern uint TotalOut();
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern void WaitForWindow( int pid );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern void SetDataPath( string path );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern void CalibratePosition( uint x, uint y, uint z, byte dir );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern void SetServer( uint ip, ushort port );
+        [DllImport( "Crypt.dll" )]
+        internal static unsafe extern string GetUOVersion();
+
+        [DllImport( "WinUtil.dll" )]
+        internal static unsafe extern IntPtr CaptureScreen( IntPtr handle, bool isFullScreen, string msgStr );
+        [DllImport( "WinUtil.dll" )]
+        internal static unsafe extern void BringToFront( IntPtr hWnd );
+        [DllImport( "WinUtil.dll" )]
+        internal static unsafe extern int HandleNegotiate( ulong word );
+        [DllImport( "WinUtil.dll" )]
+        internal static unsafe extern bool AllowBit( ulong bit );
+
+        [DllImport( "Loader.dll" )]
+        internal static unsafe extern uint Load( string exe, string dll, string func, void* dllData, int dataLen, out uint pid );
+
+        [DllImport( "msvcrt.dll" )]
+        internal static unsafe extern void memcpy( void* to, void* from, int len );
+
+        [DllImport( "user32.dll" )]
+        internal static extern uint PostMessage( IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam );
+        [DllImport( "user32.dll" )]
+        internal static extern bool SetForegroundWindow( IntPtr hWnd );
+
+        [DllImport( "kernel32.dll" )]
+        internal static extern uint GlobalGetAtomName( ushort atom, StringBuilder buff, int bufLen );
+
+        [DllImport( "Advapi32.dll" )]
+        internal static extern int GetUserNameA( StringBuilder buff, int* len );
+
+        [DllImport( "user32.dll" )]
+        internal static extern IntPtr SendMessage( IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam );
+
+        public static string GetWindowsUserName()
+        {
+            int len = 1024;
+            StringBuilder sb = new StringBuilder( len );
+            if ( GetUserNameA( sb, &len ) != 0 )
+                return sb.ToString();
+            else
+                return "";
+        }
+    }
+}

--- a/Razor/Network/ClientComm/CUOClientCommunication.cs
+++ b/Razor/Network/ClientComm/CUOClientCommunication.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Assistant
+{
+    class CUOClientCommunication : ClientCommunication
+    {
+        internal override Version GetUOVersion()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Razor/Network/ClientComm/OSIClientCommunication.cs
+++ b/Razor/Network/ClientComm/OSIClientCommunication.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Assistant
+{
+    public class OSIClientCommunication : ClientCommunication
+    {
+
+        internal override Version GetUOVersion()
+        {
+            Version result;
+            string[] split = NativeMethods.GetUOVersion().Split( '.' );
+
+            if ( split.Length < 3 )
+                result = new Version( 4, 0, 0, 0 );
+
+            int rev = 0;
+
+            if ( split.Length > 3 )
+                rev = Utility.ToInt32( split[3], 0 );
+
+            result = new Version(
+                Utility.ToInt32( split[0], 0 ),
+                Utility.ToInt32( split[1], 0 ),
+                Utility.ToInt32( split[2], 0 ),
+                rev );
+
+            if ( result == null || result.Major == 0 ) // sanity check if the client returns 0.0.0.0
+                result = new Version( 4, 0, 0, 0 );
+            return result;
+        }
+    }
+}

--- a/Razor/Network/PacketTable.cs
+++ b/Razor/Network/PacketTable.cs
@@ -289,10 +289,10 @@ namespace Assistant
             return (_packetsTable[id] == -1);
         }
 
-        public static void AdjustPacketSizeByVersion(Version version)
+        public static void AdjustPacketSizeByVersion( Version version )
         {
             /* TODO: This should really be 5.0.0.a */
-            if (version.Major >= 5)
+            if ( version >= new Version( 5, 0, 0, 0 ) )
             {
                 _packetsTable[0x0B] = 0x07;
                 _packetsTable[0x16] = -1;
@@ -305,12 +305,12 @@ namespace Assistant
                 _packetsTable[0x31] = 0x01;
             }
 
-            if (version.Major >= 5 && version.Build >= 9)
+            if ( version >= new Version( 5, 0, 9, 0 ) )
                 _packetsTable[0xE1] = -1;
             else
                 _packetsTable[0xE1] = 0x09;
 
-            if (version.Major >= 6 && version.Build >= 13)
+            if ( version >= new Version( 6, 0, 13, 0 ) )
             {
                 _packetsTable[0xE3] = -1;
                 _packetsTable[0xE6] = 0x05;
@@ -329,7 +329,7 @@ namespace Assistant
                 _packetsTable[0xEA] = -1;
             }
 
-            if (version.Major >= 6 && version.Build >= 17)
+            if ( version >= new Version( 6, 0, 17, 0 ) )
             {
                 _packetsTable[0x08] = 0x0F;
                 _packetsTable[0x25] = 0x15;
@@ -340,7 +340,7 @@ namespace Assistant
                 _packetsTable[0x25] = 0x14;
             }
 
-            if (version.Major >= 6 && version.Build >= 6)
+            if ( version >= new Version( 6, 0, 6, 0 ) )
             {
                 _packetsTable[0xEE] = 0x2000;
                 _packetsTable[0xEF] = 0x2000;
@@ -353,12 +353,12 @@ namespace Assistant
                 _packetsTable[0xF1] = -1;
             }
 
-            if (version.Major >= 6 && version.Build >= 14 && version.Revision >= 2)
+            if ( version >= new Version( 6, 0, 14, 2 ) )
                 _packetsTable[0xB9] = 0x05;
             else
                 _packetsTable[0xB9] = 0x03;
 
-            if (version.Major >= 7)
+            if ( version >= new Version( 7, 0, 0, 0 ) )
             {
                 _packetsTable[0xEE] = 0x0A; //0x2000;
                 _packetsTable[0xEF] = 0x15; //0x2000;
@@ -369,7 +369,7 @@ namespace Assistant
                 _packetsTable[0xEF] = 0x15;
             }
 
-            if (version.Major >= 7 && version.Build >= 9)
+            if ( version >= new Version( 7, 0, 9, 0 ) )
             {
                 _packetsTable[0x24] = 0x09;
                 _packetsTable[0x99] = 0x1E;
@@ -388,7 +388,7 @@ namespace Assistant
                 _packetsTable[0xF2] = -1;
             }
 
-            if (version.Major >= 7 && version.Build >= 18)
+            if ( version >= new Version( 7, 0, 18, 0 ) )
                 _packetsTable[0x00] = 0x6A;
             else
                 _packetsTable[0x00] = 0x68;

--- a/Razor/Razor.csproj
+++ b/Razor/Razor.csproj
@@ -247,9 +247,12 @@
     <Compile Include="Core\MsgQueue.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="Network\ClientComm.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Network\ClientComm\CUOClientCommunication.cs" />
+    <Compile Include="Network\ClientComm\OSIClientCommunication.cs" />
     <Compile Include="Network\Handlers.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -436,6 +439,8 @@
     <Content Include="Boat\Images\southeast.png" />
     <Content Include="Boat\Images\southwest.png" />
     <Content Include="Boat\Images\west.png" />
+    <Content Include="cuoapi.dll" />
+    <Content Include="cuoapi.pdb" />
     <Content Include="UI\Lock.ico" />
     <Content Include="UI\UOPS.ico" />
   </ItemGroup>

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -7337,7 +7337,7 @@ namespace Assistant
         {
             // Fuck windows, seriously.
 
-            ClientCommunication.BringToFront(this.Handle);
+            NativeMethods.BringToFront(this.Handle);
             if (Config.GetBool("AlwaysOnTop"))
                 this.TopMost = true;
             if (WindowState != FormWindowState.Normal)


### PR DESCRIPTION
Fixes ClientVersion packetlen checks failing, ie 0xb9 was getting set to 0x03 for low 7 series clients.

Starts refactoring Client Comm into two seperate classes and moving Native Methods to their own class.
Will keep at this just PR'ing in a small chunk to make sure your all happy with the direction.
