### PR TITLE
Next Target ignores friends if configured

### DIFF
--- a/Razor/Core/TargetingNextPrevious.cs
+++ b/Razor/Core/TargetingNextPrevious.cs
@@ -190,7 +190,7 @@ namespace Assistant
 
         private static void NextTarget()
         {
-            var mobiles = World.MobilesInRange();
+            var mobiles = World.MobilesInRange().Where(x => !IsNextPrevFriend(x)).ToList();
 
             NextPrevTarget(mobiles, true);
         }


### PR DESCRIPTION
Restores the behavior removed in https://github.com/markdwags/Razor/commit/d3675ffef04f52b8c2faf7716e18e3d0d0ffb4b0 as mentioned in Discord. If its intentional to move away from this then maybe it's worth adding a similar `Next Target`. `Next Monster Target` doesn't work in this case as I'm using the friends list to ignore my pets (which are of course friendly monsters). I like using `Next Target` since I can cycle through blues and mosnters as needed (and just aggressively add the chill people to friends list :))