### PR TITLE
Improve BandageTimer

### DIFF
--- a/Razor/Core/BandageTimer.cs
+++ b/Razor/Core/BandageTimer.cs
@@ -46,7 +46,23 @@ namespace Assistant
             {
                 if (num == 500955 || (num >= 500962 && num <= 500969) || (num >= 503252 && num <= 503261) ||
                     num == 1010058 || num == 1010648 || num == 1010650 || num == 1060088 || num == 1060167)
+                {
                     Stop();
+
+                    if (Config.GetBool("ShowBandageTimer"))
+                        ShowBandagingStatusMessage("Bandaging done!");
+                }
+            }
+            else
+            {
+                // Start timer as soon as there is the "You begin applying the bandages." message
+                if (num == 500956)
+                {
+                    Start();
+
+                    if (Config.GetBool("ShowBandageTimer"))
+                        ShowBandagingStatusMessage("Bandaging started...");
+                }
             }
         }
 
@@ -54,13 +70,38 @@ namespace Assistant
         {
             if (Running)
             {
+                if (msg == "You heal what little damage you had." || msg == "You heal what little damage the patient had.")
+                {
+                    Stop();
+
+                    if (Config.GetBool("ShowBandageTimer"))
+                        ShowBandagingStatusMessage("Bandaging done!");
+
+                    return;
+                }
+
                 foreach (var t in m_ClilocNums)
                 {
                     if (Language.GetCliloc(t) == msg)
                     {
                         Stop();
+
+                        if (Config.GetBool("ShowBandageTimer"))
+                            ShowBandagingStatusMessage("Bandaging done!");
+
                         break;
                     }
+                }
+            }
+            else
+            {
+                // Start timer as soon as there is the "You begin applying the bandages." message
+                if (msg == "You begin applying the bandages.")
+                {
+                    Start();
+
+                    if (Config.GetBool("ShowBandageTimer"))
+                        ShowBandagingStatusMessage("Bandaging started...");
                 }
             }
         }
@@ -91,6 +132,18 @@ namespace Assistant
             Client.Instance.RequestTitlebarUpdate();
         }
 
+        public static void ShowBandagingStatusMessage(string msg)
+        {
+            if (Config.GetInt("ShowBandageTimerLocation") == 0)
+            {
+                World.Player.OverheadMessage(Config.GetInt("ShowBandageTimerHue"), msg);
+            }
+            else
+            {
+                World.Player.SendMessage(Config.GetInt("ShowBandageTimerHue"), msg);
+            }
+        }
+
         private class InternalTimer : Timer
         {
             public InternalTimer() : base(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1))
@@ -107,16 +160,7 @@ namespace Assistant
                                          m_Count % Config.GetInt("OnlyShowBandageTimerSeconds") != 0);
 
                     if (showMessage)
-                    {
-                        if (Config.GetInt("ShowBandageTimerLocation") == 0)
-                        {
-                            World.Player.OverheadMessage(Config.GetInt("ShowBandageTimerHue"), Config.GetString("ShowBandageTimerFormat").Replace("{count}", m_Count.ToString()));
-                        }
-                        else
-                        {
-                            World.Player.SendMessage(Config.GetInt("ShowBandageTimerHue"), Config.GetString("ShowBandageTimerFormat").Replace("{count}", m_Count.ToString()));
-                        }
-                    }
+                        ShowBandagingStatusMessage(Config.GetString("ShowBandageTimerFormat").Replace("{count}", m_Count.ToString()));
                 }
 
                 if (m_Count > 30)

--- a/Razor/HotKeys/Misc.cs
+++ b/Razor/HotKeys/Misc.cs
@@ -285,7 +285,7 @@ namespace Assistant.HotKeys
                 else
                 {
                     Targeting.LastTarget(true); //force a targetself to be queued
-                    BandageTimer.Start();
+                    //BandageTimer.Start(); // Bandage timer will be started automatically after the "You begin applying the bandages." message
                 }
             }
         }
@@ -303,7 +303,7 @@ namespace Assistant.HotKeys
                 {
                     Targeting.ClearQueue();
                     Targeting.TargetSelf(true); //force a targetself to be queued
-                    BandageTimer.Start();
+                    //BandageTimer.Start(); // Bandage timer will be started automatically after the "You begin applying the bandages." message
                 }
             }
         }


### PR DESCRIPTION
Make starting and stopping of BandageTimer more robust and not rely on hotkeys: timer will be started as soon as client receives "You begin applying the bandages." message, and stopped when various messages received (added support for "You heal what little damage..." type of messages for the stop event). Also, if displaying of BandageTimer is enabled in settings, explicit "Bandaging started..." and "Bandaging done!" messages will be shown before and after counting.

P.S. Also, I can add a feature/setting that will prevent bandaging again until current bandaging process is finished (this can significantly help in situations when your bandaging is almost done and you accidentally hit BandageSelf again causing bandaging process to start over without any heal from the interrupted process).