### PR TITLE
For ClassicUO, dont trigger Hotkey.OnKeyDown if key is a modifier key

### DIFF
--- a/Razor/Client/ClassicUO.cs
+++ b/Razor/Client/ClassicUO.cs
@@ -320,9 +320,19 @@ namespace Assistant
             KMOD_RESERVED = 0x8000
         }
 
+        private enum SDL_Keycode_Ignore
+        {
+            SDLK_LCTRL = 1073742048,
+            SDLK_LSHIFT = 1073742049,
+            SDLK_LALT = 1073742050,
+            SDLK_RCTRL = 1073742052,
+            SDLK_RSHIFT = 1073742053,
+            SDLK_RALT = 1073742054,
+        }
+
         private bool OnHotKeyHandler(int key, int mod, bool ispressed)
         {
-            if (ispressed)
+            if (ispressed && !Enum.IsDefined(typeof(SDL_Keycode_Ignore), key))
             {
                 ModKeys cur = ModKeys.None;
                 SDL_Keymod keymod = (SDL_Keymod) mod;


### PR DESCRIPTION
CUO sends Ctrl/Alt/Shift as hotkeys to Razor, even though Razor doesn't act on them. Usually harmless, but Drasked experiences spammy hotkeys because of two things:

- Binding Control to a mouse key means it when it is held, it doesn't stop being repeated after pressing another key. Normally with a keyboard, the second keypress stops Control from being repeated.
- Razor checks for keys which are currently down other than the one CUO sent.

This means repeated hotkey calls for Control can find other keys which are down i.e. the hotkey you momentarily pressed. Even though it's only down for a short while, it's long enough to trigger the hotkey multiple times. The same applies if Control is held on a keyboard and the actual hotkey sent from a mouse or other device (e.g. onscreen keyboard)

https://www.youtube.com/watch?v=G9A6Eas9L4E

I think this fix is better than doing it in CUO, since in CUO "plugin" does not necessarily mean Razor. Who can say that other assistants don't want to know about Ctrl being pressed?

What do you think?