### PR TITLE
Add packets 0xFA (length 1) and 0xFB (length 2)

### DIFF
--- a/Razor/Network/PacketTable.cs
+++ b/Razor/Network/PacketTable.cs
@@ -256,8 +256,8 @@ namespace Assistant
             -1, // f7
             0x6A, // f8
             -1, // f9
-            -1, // fa
-            -1, // fb
+            0x01, // fa
+            0x02, // fb
             -1, // fc
             -1, // fd
             -1 // ff


### PR DESCRIPTION
Adds packets [0xFA](https://docs.polserver.com/packets/index.php?Packet=0xFA) and [0xFB](https://docs.polserver.com/packets/index.php?Packet=0xFB) to packet table