### PR TITLE
Add Loader.def to project module definition in Debug configuration

### DIFF
--- a/Loader/Loader.vcxproj
+++ b/Loader/Loader.vcxproj
@@ -63,6 +63,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ModuleDefinitionFile>Loader.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Adds missing `Loader.def` to the module definition file in the debug configuration