### PR TITLE
Disposes systray icon after exit

### DIFF
--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -3921,6 +3921,8 @@ namespace Assistant
 
         private void OnClose(object sender, System.EventArgs e)
         {
+            m_NotifyIcon.Visible = false;
+            m_NotifyIcon.Dispose();
             m_CanClose = true;
             this.Close();
         }


### PR DESCRIPTION
Razor systray icon was left behind after closing the client