### PR TITLE
fix discord overlay system access violation crash

### DIFF
--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -4026,12 +4026,12 @@ namespace Assistant
 
         private void tabs_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
         {
-            HotKey.KeyDown(e.KeyData);
+            //HotKey.KeyDown(e.KeyData);
         }
 
         private void MainForm_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
         {
-            HotKey.KeyDown(e.KeyData);
+            //HotKey.KeyDown(e.KeyData);
         }
 
         private void spellUnequip_CheckedChanged(object sender, System.EventArgs e)


### PR DESCRIPTION
The commented code does nothing except return the state of a key, so it's not achieving anything. But it has caused ClassicUO crashes when using Discord's ingame overlay, and pressing Ctrl or Alt or Shift with a tab or form element focused.

I had thought to catch the exception but all advice is not to catch System.AccessViolationException (and by default you can't)