### PR TITLE
let hits and maxhits operate on others as well as self

### DIFF
--- a/Razor/Scripts/Expressions.cs
+++ b/Razor/Scripts/Expressions.cs
@@ -235,18 +235,62 @@ namespace Assistant.Scripts
 
         private static double Hp(string expression, Argument[] args, bool quiet)
         {
-            if (World.Player == null)
-                return 0;
+            if (args.Length < 1)
+            {
+                if (World.Player == null)
+                    return 0;
 
-            return World.Player.Hits;
+                return World.Player.Hits;
+            }
+            else
+            {
+                Serial serial = args[0].AsSerial();
+
+                if (!serial.IsValid)
+                {
+                    ScriptManager.Error("hp/hits - invalid serial");
+                    return 0;
+                }
+
+                Mobile m = World.FindMobile(serial);
+
+                if (m != null)
+                {
+                    return m.Hits;
+                }
+
+                return Double.MaxValue;
+            }
         }
 
         private static double MaxHp(string expression, Argument[] args, bool quiet)
         {
-            if (World.Player == null)
-                return 0;
+            if (args.Length < 1)
+            {
+                if (World.Player == null)
+                    return 0;
 
-            return World.Player.HitsMax;
+                return World.Player.HitsMax;
+            }
+            else
+            {
+                Serial serial = args[0].AsSerial();
+
+                if (!serial.IsValid)
+                {
+                    ScriptManager.Error("maxhp/maxhits - invalid serial");
+                    return 0;
+                }
+
+                Mobile m = World.FindMobile(serial);
+
+                if (m != null)
+                {
+                    return m.HitsMax;
+                }
+
+                return Double.MaxValue;
+            }
         }
 
         private static double Stam(string expression, Argument[] args, bool quiet)
@@ -326,5 +370,6 @@ namespace Assistant.Scripts
 
             return 0;
         }
+
     }
 }


### PR DESCRIPTION
`hp` and `hits` as well as `maxhp` and `maxhits` now accepts an optional serial argument.

it continues to work e.g.
```
if hits < maxhits
    overhead 'self not at full health'
else
    overhead 'self at full health'
endif
```

but also allows you to test other mobiles e.g.
```
if hits 'mypet' < maxhits 'mypet'
    overhead 'my pet is not at full health'
else
    overhead 'my pet is at full health'
endif
```

if the serial is not found in `World`, Double.MaxValue is returned rather than 0.  this is more desirable behavior in the majority of real-world scenarios.