### PR TITLE
Fix dynamic assembly loading 

### DIFF
--- a/Razor/Client/ClassicUO.cs
+++ b/Razor/Client/ClassicUO.cs
@@ -67,6 +67,21 @@ namespace Assistant
                 return;
             }
 
+            // load ultimasdk before or the Language.Load will throw the cliloc not found warning every time you run cuo
+            string clientPath =
+                ((OnGetUOFilePath) Marshal.GetDelegateForFunctionPointer(plugin->GetUOFilePath, typeof(OnGetUOFilePath))
+                )();
+
+            // just replicating the static .ctor
+            Ultima.Files.ReLoadDirectory();
+            Ultima.Files.LoadMulPath();
+
+            Ultima.Files.SetMulPath(clientPath);
+            Ultima.Multis.PostHSFormat = UsePostHSChanges;
+            Client.Instance.ClientEncrypted = false;
+            Client.Instance.ServerEncrypted = false;
+
+
             /* Load localization files */
             if (!Language.Load("ENU"))
             {
@@ -79,15 +94,6 @@ namespace Assistant
             }
 
             m_Running = true;
-
-            string clientPath =
-                ((OnGetUOFilePath) Marshal.GetDelegateForFunctionPointer(plugin->GetUOFilePath, typeof(OnGetUOFilePath))
-                )();
-
-            Ultima.Files.SetMulPath(clientPath);
-            Ultima.Multis.PostHSFormat = UsePostHSChanges;
-            Client.Instance.ClientEncrypted = false;
-            Client.Instance.ServerEncrypted = false;
 
             Language.LoadCliLoc();
 

--- a/Razor/Razor.csproj
+++ b/Razor/Razor.csproj
@@ -578,6 +578,6 @@
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>
-    <PostBuildEvent>xcopy /S /Q /Y $(SolutionDir)etc\* $(SolutionDir)bin\Win32\$(Configuration)\</PostBuildEvent>
+    <PostBuildEvent>xcopy /S /Q /Y "$(SolutionDir)etc\*" "$(SolutionDir)bin\Win32\$(Configuration)\"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Razor/Razor.csproj
+++ b/Razor/Razor.csproj
@@ -123,8 +123,8 @@
       <HintPath>.\cuoapi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/Razor/UltimaSDK/Files.cs
+++ b/Razor/UltimaSDK/Files.cs
@@ -209,11 +209,6 @@ namespace Ultima
             "verdata.mul"
         };
 
-        static Files()
-        {
-            m_Directory = LoadDirectory();
-            LoadMulPath();
-        }
 
         /// <summary>
         /// ReReads Registry Client dir
@@ -349,13 +344,15 @@ namespace Ultima
             // If they're using the ClassicUO client, pull the UO data dir from the plugin
             if (!Assistant.Client.IsOSI)
             {
-                //dir = Assistant.Client.Instance.GetUoFilePath();
-
                 // Check in the root of this process for the file
                 if (File.Exists("settings.json"))
                 {
                     dynamic cuoJson = JObject.Parse(File.ReadAllText("settings.json"));
                     dir = cuoJson.ultimaonlinedirectory.ToString();
+                }
+                else
+                {
+                    dir = Assistant.Client.Instance.GetUoFilePath();
                 }
             }
 

--- a/Razor/packages.config
+++ b/Razor/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net40-client" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This fix aims to solve the issue after Newtonsoft.Json lib remotion from ClassicUO.
Infact Razor used the same assembly instead of use it's own.
In addition it solves the cliloc warning message caused to an uninitialized path.