### PR TITLE
Update ActionQueue.cs

### DIFF
--- a/Razor/Core/ActionQueue.cs
+++ b/Razor/Core/ActionQueue.cs
@@ -283,6 +283,7 @@ namespace Assistant
                 Log("Equipping {0} to {1} (@{2})", i, to.Serial, layer);
                 Client.Instance.SendToServer(new EquipRequest(i.Serial, to, layer));
                 m_Pending = Serial.Zero;
+                EndHolding(i.Serial);
                 m_Lifted = DateTime.MinValue;
                 return true;
             }
@@ -544,6 +545,7 @@ namespace Assistant
                 if (dr != null)
                 {
                     m_Pending = Serial.Zero;
+                    EndHolding(lr.Serial);
                     m_Lifted = DateTime.MinValue;
 
                     Log("Dropping {0} to {1}", lr, dr.Serial);


### PR DESCRIPTION
this fixes this particular case:

If you grab a pile of items and stack it with another pile of same item, the old item, deleted afterward by the server, won't be removed from the dictionary, thus leaving an unexistant item in the dictionary and an invalid reference for all the searches that the assistant could do, this could be also related to the bug where, sometimes, the scavenger won't correctly work, since the assistant will still see the item in the world and try to grab the unexistant one.