### PR TITLE
Update BuyAgent.cs

### DIFF
--- a/Razor/Agents/BuyAgent.cs
+++ b/Razor/Agents/BuyAgent.cs
@@ -194,11 +194,13 @@ namespace Assistant.Agents
                             if (count < b.Amount && b.Amount > 0)
                             {
                                 count = b.Amount - count;
-                                if (count > item.Amount)
+                                if (count >= item.Amount)
                                 {
                                     count = item.Amount;
+                                    if (pack.Contains.Remove(item))
+                                        --i;
                                 }
-                                else if (count <= 0)
+                                if (count <= 0)
                                 {
                                     continue;
                                 }


### PR DESCRIPTION
this fixes another ancient bug, where the vendor pack items don't get updated realtime by the server (it's managed client side). the assistant should behave exactly like this.
this will remove the warning in extinfos with amounts not matching.