### PR TITLE
This is a workaround for the uncleaned lists, for the assistant

### DIFF
--- a/Razor/Agents/BuyAgent.cs
+++ b/Razor/Agents/BuyAgent.cs
@@ -198,10 +198,8 @@ namespace Assistant.Agents
                                 if (count >= item.Amount)
                                 {
                                     count = item.Amount;
-                                    if (pack.Contains.Remove(item))
-                                        --i;
                                 }
-                                if (count <= 0)
+                                else if (count <= 0)
                                 {
                                     continue;
                                 }
@@ -256,6 +254,7 @@ namespace Assistant.Agents
             if (buyList.Count > 0)
             {
                 args.Block = true;
+                BuyLists[serial] = buyList;
                 Client.Instance.SendToServer(new VendorBuyResponse(serial, buyList));
                 World.Player.SendMessage(MsgLevel.Force, LocString.BuyTotals, total, cost);
             }

--- a/Razor/Client/ClassicUO.cs
+++ b/Razor/Client/ClassicUO.cs
@@ -399,6 +399,7 @@ namespace Assistant
                 Engine.MainWindow.MapWindow.Close();
             PacketHandlers.Party.Clear();
             PacketHandlers.IgnoreGumps.Clear();
+            Agents.BuyAgent.OnDisconnected();
             Config.Save();
         }
 

--- a/Razor/Client/OSI.cs
+++ b/Razor/Client/OSI.cs
@@ -472,6 +472,7 @@ namespace Assistant
                 Engine.MainWindow.MapWindow.Close();
             PacketHandlers.Party.Clear();
             PacketHandlers.IgnoreGumps.Clear();
+            Agents.BuyAgent.OnDisconnected();
             Config.Save();
 
             //TranslateEnabled = false;


### PR DESCRIPTION
this is a completely different method, once we buy the items, we cleanup the internal list of item when they reach amount of zero.

This way, in case of an unsuccessful buy, there will be no item removal.