### PR TITLE
Update Controls to .net core 3.1 compatible versions

### DIFF
--- a/Razor/Macros/Actions.cs
+++ b/Razor/Macros/Actions.cs
@@ -30,7 +30,7 @@ namespace Assistant.Macros
 {
     public delegate void MacroMenuCallback(object[] Args);
 
-    public class MacroMenuItem : MenuItem
+    public class MacroMenuItem : ToolStripMenuItem
     {
         private MacroMenuCallback m_Call;
         private object[] m_Args;
@@ -77,7 +77,7 @@ namespace Assistant.Macros
             return sb.ToString();
         }
 
-        public virtual MenuItem[] GetContextMenuItems()
+        public virtual ToolStripMenuItem[] GetContextMenuItems()
         {
             return null;
         }
@@ -178,9 +178,9 @@ namespace Assistant.Macros
             return $"// {m_Comment}";
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -241,6 +241,7 @@ namespace Assistant.Macros
         }
     }
 
+
     public class DoubleClickAction : MacroAction
     {
         private Serial m_Serial;
@@ -279,9 +280,9 @@ namespace Assistant.Macros
             return Language.Format(LocString.DClickA1, m_Serial);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -451,9 +452,9 @@ namespace Assistant.Macros
                 m_Item ? ((ItemID) m_Gfx).ToString() : $"(Character) 0x{m_Gfx:X}");
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -550,9 +551,9 @@ namespace Assistant.Macros
             return Language.Format(LocString.LiftA10, m_Serial, m_Amount);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -672,9 +673,9 @@ namespace Assistant.Macros
             return DoSerialize(m_Gfx, m_Amount);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -793,9 +794,9 @@ namespace Assistant.Macros
                 return Language.Format(LocString.DropA2, m_To.IsValid ? m_To.ToString() : "Ground", m_At);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_To.IsValid)
             {
@@ -933,12 +934,12 @@ namespace Assistant.Macros
                 return Language.Format(LocString.CloseGump);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (this.m_MenuItems == null)
-                this.m_MenuItems = (MenuItem[]) new MacroMenuItem[]
+                this.m_MenuItems = (ToolStripMenuItem[]) new MacroMenuItem[]
                 {
                     new MacroMenuItem(LocString.UseLastGumpResponse, new MacroMenuCallback(this.UseLastResponse),
                         new object[0]),
@@ -1060,9 +1061,9 @@ namespace Assistant.Macros
             return Language.GetString(LocString.AbsTarg);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -1376,9 +1377,9 @@ namespace Assistant.Macros
                 return Language.Format(LocString.TargByType, (ItemID) m_Gfx);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -1467,9 +1468,9 @@ namespace Assistant.Macros
             return Language.Format(LocString.TargRelLocA3, m_X, m_Y, 0);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -1786,12 +1787,12 @@ namespace Assistant.Macros
             return sb.ToString();
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (this.m_MenuItems == null)
-                this.m_MenuItems = (MenuItem[]) new MacroMenuItem[1]
+                this.m_MenuItems = (ToolStripMenuItem[]) new MacroMenuItem[1]
                 {
                     new MacroMenuItem(LocString.Edit, new MacroMenuCallback(this.Edit), new object[0])
                 };
@@ -1863,9 +1864,9 @@ namespace Assistant.Macros
             return sb.ToString();
         }
 
-        private MenuItem[] _menuItems;
+        private ToolStripMenuItem[] _menuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             return _menuItems ?? (_menuItems = new MacroMenuItem[]
             {
@@ -1888,11 +1889,12 @@ namespace Assistant.Macros
 
             if (h.ShowDialog(Engine.MainWindow) == DialogResult.OK)
             {
-                _hue = (ushort) h.Hue;
+                _hue = (ushort)h.Hue;
             }
 
             Parent?.Update();
         }
+
     }
 
     public class UseSkillAction : MacroAction
@@ -2369,9 +2371,9 @@ namespace Assistant.Macros
             return false;
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -2477,9 +2479,9 @@ namespace Assistant.Macros
             return false;
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -2558,9 +2560,9 @@ namespace Assistant.Macros
             return DoSerialize(m_Timeout.TotalSeconds);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -2628,9 +2630,9 @@ namespace Assistant.Macros
             return Language.Format(LocString.PauseA1, m_Timeout.TotalSeconds);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -2763,9 +2765,9 @@ namespace Assistant.Macros
             return Language.Format(LocString.WaitA3, m_Stat, m_Direction > 0 ? ">=" : "<=", m_Value);
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -3273,9 +3275,9 @@ namespace Assistant.Macros
             }
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -3435,9 +3437,9 @@ namespace Assistant.Macros
             return $"For ( 1 to {m_Max} )";
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -3967,9 +3969,9 @@ namespace Assistant.Macros
             }
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -4453,9 +4455,9 @@ namespace Assistant.Macros
             }
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {
@@ -4579,12 +4581,12 @@ namespace Assistant.Macros
             return $"PromptAction: {m_Response}";
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (this.m_MenuItems == null)
-                this.m_MenuItems = (MenuItem[]) new MacroMenuItem[1]
+                this.m_MenuItems = (ToolStripMenuItem[]) new MacroMenuItem[1]
                 {
                     new MacroMenuItem(LocString.Edit, new MacroMenuCallback(this.Edit), new object[0])
                 };
@@ -4682,9 +4684,9 @@ namespace Assistant.Macros
             return false;
         }
 
-        private MenuItem[] m_MenuItems;
+        private ToolStripMenuItem[] m_MenuItems;
 
-        public override MenuItem[] GetContextMenuItems()
+        public override ToolStripMenuItem[] GetContextMenuItems()
         {
             if (m_MenuItems == null)
             {

--- a/Razor/Map/MapWindow.cs
+++ b/Razor/Map/MapWindow.cs
@@ -52,8 +52,8 @@ namespace Assistant.MapUO
             // Required for Windows Form Designer support
             //
             InitializeComponent();
-            this.ContextMenu = new ContextMenu();
-            this.ContextMenu.Popup += new EventHandler(ContextMenu_Popup);
+            this.ContextMenuStrip = new ContextMenuStrip();
+            this.ContextMenuStrip.Opening += ContextMenu_Popup;
             this.Location = new Point(Config.GetInt("MapX"), Config.GetInt("MapY"));
             this.ClientSize = new Size(Config.GetInt("MapW"), Config.GetInt("MapH"));
 
@@ -73,9 +73,9 @@ namespace Assistant.MapUO
             Client.Instance.SetMapWndHandle(this);
         }
 
-        public class MapMenuItem : MenuItem
+        public class MapMenuItem : ToolStripMenuItem
         {
-            public MapMenuItem(System.String text, System.EventHandler onClick) : base(text, onClick)
+            public MapMenuItem(System.String text, System.EventHandler onClick) : base(text, null, onClick)
             {
                 Tag = null;
             }
@@ -83,13 +83,13 @@ namespace Assistant.MapUO
 
         void ContextMenu_Popup(object sender, EventArgs e)
         {
-            ContextMenu cm = this.ContextMenu;
-            cm.MenuItems.Clear();
+            ContextMenuStrip cm = this.ContextMenuStrip;
+            cm.Items.Clear();
             if (World.Player != null && PacketHandlers.Party.Count > 0)
             {
                 MapMenuItem mi = new MapMenuItem("You", new EventHandler(FocusChange));
                 mi.Tag = World.Player.Serial;
-                cm.MenuItems.Add(mi);
+                cm.Items.Add(mi);
                 foreach (Serial s in PacketHandlers.Party)
                 {
                     Mobile m = World.FindMobile(s);
@@ -99,12 +99,12 @@ namespace Assistant.MapUO
                         mi.Tag = s;
                         if (this.Map.FocusMobile == m)
                             mi.Checked = true;
-                        cm.MenuItems.Add(mi);
+                        cm.Items.Add(mi);
                     }
                 }
             }
 
-            this.ContextMenu = cm;
+            this.ContextMenuStrip = cm;
         }
 
 

--- a/Razor/UI/ContainerLabels.cs
+++ b/Razor/UI/ContainerLabels.cs
@@ -336,8 +336,8 @@ namespace Assistant.UI
 
             if (e.Button == MouseButtons.Right && e.Clicks == 1)
             {
-                ContextMenu menu = new ContextMenu();
-                menu.MenuItems.Add("Open Container (if in range)", new EventHandler(OnContainerDoubleClick));
+                ContextMenuStrip menu = new ContextMenuStrip();
+                menu.Items.Add("Open Container (if in range)", null, new EventHandler(OnContainerDoubleClick));
 
                 menu.Show(containerView, new Point(e.X, e.Y));
             }

--- a/Razor/UI/Razor.Designer.cs
+++ b/Razor/UI/Razor.Designer.cs
@@ -331,17 +331,15 @@ namespace Assistant
             //
             InitializeComponent();
 
-            m_NotifyIcon.ContextMenu =
-                new ContextMenu(new MenuItem[]
-                {
-                    new MenuItem("Show Razor", new EventHandler(DoShowMe)),
-                    new MenuItem("Hide Razor", new EventHandler(HideMe)),
-                    new MenuItem("-"),
-                    new MenuItem("Toggle Razor Visibility", new EventHandler(ToggleVisible)),
-                    new MenuItem("-"),
-                    new MenuItem("Close Razor && UO", new EventHandler(OnClose))
-                });
-            m_NotifyIcon.ContextMenu.MenuItems[0].DefaultItem = true;
+            m_NotifyIcon.ContextMenuStrip = new ContextMenuStrip();
+            m_NotifyIcon.ContextMenuStrip.Items.Add("Show Razor", null, new EventHandler(DoShowMe));
+            m_NotifyIcon.ContextMenuStrip.Items.Add("Hide Razor", null, new EventHandler(HideMe));
+            m_NotifyIcon.ContextMenuStrip.Items.Add("-");
+            m_NotifyIcon.ContextMenuStrip.Items.Add("Toggle Razor Visibility", null, new EventHandler(ToggleVisible));
+            m_NotifyIcon.ContextMenuStrip.Items.Add("-");
+            m_NotifyIcon.ContextMenuStrip.Items.Add("Close Razor && UO", null, new EventHandler(OnClose));
+
+            m_NotifyIcon.ContextMenuStrip.Items[0].Select();
         }
 
         /// <summary>

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -496,7 +496,7 @@ namespace Assistant
             scriptFindTypeRange.SafeAction(s => { s.Checked = Config.GetBool("ScriptFindTypeRange"); });
 
             scriptDisablePlayFinish.SafeAction(s => { s.Checked = Config.GetBool("ScriptDisablePlayFinish"); });
-            
+
             showWaypointOverhead.SafeAction(s => { s.Checked = Config.GetBool("ShowWaypointOverhead"); });
             showWaypointDistance.SafeAction(s => { s.Checked = Config.GetBool("ShowWaypointDistance"); });
             txtWaypointDistanceSec.SafeAction(s => { s.Text = Config.GetInt("ShowWaypointSeconds").ToString(); });
@@ -958,7 +958,7 @@ namespace Assistant
             Config.SetProperty("ShowCorpseNames", incomingCorpse.Checked);
         }
 
-        private ContextMenu m_SkillMenu;
+        private ContextMenuStrip m_SkillMenu;
 
         private void skillList_MouseDown(object sender, System.Windows.Forms.MouseEventArgs e)
         {
@@ -973,16 +973,14 @@ namespace Assistant
 
                 if (m_SkillMenu == null)
                 {
-                    m_SkillMenu = new ContextMenu(new MenuItem[]
-                    {
-                        new MenuItem(Language.GetString(LocString.SetSLUp), new EventHandler(onSetSkillLockUP)),
-                        new MenuItem(Language.GetString(LocString.SetSLDown), new EventHandler(onSetSkillLockDOWN)),
-                        new MenuItem(Language.GetString(LocString.SetSLLocked), new EventHandler(onSetSkillLockLOCKED))
-                    });
+                    m_SkillMenu = new ContextMenuStrip();
+                    m_SkillMenu.Items.Add(Language.GetString(LocString.SetSLUp), null, onSetSkillLockUP);
+                    m_SkillMenu.Items.Add(Language.GetString(LocString.SetSLDown), null, onSetSkillLockDOWN);
+                    m_SkillMenu.Items.Add(Language.GetString(LocString.SetSLLocked), null, onSetSkillLockLOCKED);
                 }
 
                 for (int i = 0; i < 3; i++)
-                    m_SkillMenu.MenuItems[i].Checked = ((int) s.Lock) == i;
+                    ((ToolStripMenuItem)m_SkillMenu.Items[i]).Checked = ((int) s.Lock) == i;
 
                 m_SkillMenu.Show(skillList, new Point(e.X, e.Y));
             }
@@ -2231,14 +2229,14 @@ namespace Assistant
             Config.SetAppSetting("ShowWelcome", (showWelcome.Checked ? 1 : 0).ToString());
         }
 
-        private ContextMenu m_DressItemsMenu = null;
+        private ContextMenuStrip m_DressItemsMenu = null;
 
         private void dressItems_MouseDown(object sender, System.Windows.Forms.MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Right)
             {
-                m_DressItemsMenu = new ContextMenu(new MenuItem[]
-                    {new MenuItem(Language.GetString(LocString.Conv2Type), new EventHandler(OnMakeType))});
+                m_DressItemsMenu = new ContextMenuStrip();
+                m_DressItemsMenu.Items.Add(Language.GetString(LocString.Conv2Type), null, OnMakeType);
                 m_DressItemsMenu.Show(dressItems, new Point(e.X, e.Y));
             }
         }
@@ -2464,7 +2462,7 @@ namespace Assistant
             RedrawMacros();
         }
 
-        private ContextMenu m_MacroContextMenu = null;
+        private ContextMenuStrip m_MacroContextMenu = null;
 
         private void macroTree_MouseDown(object sender, System.Windows.Forms.MouseEventArgs e)
         {
@@ -2472,26 +2470,24 @@ namespace Assistant
             {
                 if (m_MacroContextMenu == null)
                 {
-                    m_MacroContextMenu = new ContextMenu(new MenuItem[]
-                    {
-                        new MenuItem("Add Category", new EventHandler(Macro_AddCategory)),
-                        new MenuItem("Delete Category", new EventHandler(Macro_DeleteCategory)),
-                        new MenuItem("Move to Category", new EventHandler(Macro_Move2Category)),
-                        new MenuItem("-"),
-                        new MenuItem("Copy to Clipboard", new EventHandler(Macro_CopyToClipboard)),
-                        new MenuItem("Rename Macro", new EventHandler(Macro_Rename)),
-                        new MenuItem("Open Externally", new EventHandler(Open_Externally)),
-                        new MenuItem("-"),
-                        new MenuItem("Convert to Script", new EventHandler(ConvertMacroToScript)),
-                        new MenuItem("-"),
-                        new MenuItem("Refresh Macro List", new EventHandler(Macro_RefreshList))
-                    });
+                    m_MacroContextMenu = new ContextMenuStrip();
+                    m_MacroContextMenu.Items.Add("Add Category", null, Macro_AddCategory);
+                    m_MacroContextMenu.Items.Add("Delete Category", null, Macro_DeleteCategory);
+                    m_MacroContextMenu.Items.Add("Move to Category", null, Macro_Move2Category);
+                    m_MacroContextMenu.Items.Add("-");
+                    m_MacroContextMenu.Items.Add("Copy to Clipboard", null, Macro_CopyToClipboard);
+                    m_MacroContextMenu.Items.Add("Rename Macro", null, Macro_Rename);
+                    m_MacroContextMenu.Items.Add("Open Externally", null, Open_Externally);
+                    m_MacroContextMenu.Items.Add("-");
+                    m_MacroContextMenu.Items.Add("Convert to Script", null, ConvertMacroToScript);
+                    m_MacroContextMenu.Items.Add("-");
+                    m_MacroContextMenu.Items.Add("Refresh Macro List", null, Macro_RefreshList);
                 }
 
                 Macro sel = GetMacroSel();
 
-                m_MacroContextMenu.MenuItems[1].Enabled = sel == null;
-                m_MacroContextMenu.MenuItems[2].Enabled = sel != null;
+                m_MacroContextMenu.Items[1].Enabled = sel == null;
+                m_MacroContextMenu.Items[2].Enabled = sel != null;
 
                 m_MacroContextMenu.Show(this, new Point(e.X, e.Y));
             }
@@ -2942,9 +2938,9 @@ namespace Assistant
                 if (MacroManager.Playing || MacroManager.Recording || World.Player == null)
                     return;
 
-                ContextMenu menu = new ContextMenu();
-                menu.MenuItems.Add(Language.GetString(LocString.Reload), new EventHandler(onMacroReload));
-                menu.MenuItems.Add(Language.GetString(LocString.Save), new EventHandler(onMacroSave));
+                ContextMenuStrip menu = new ContextMenuStrip();
+                menu.Items.Add(Language.GetString(LocString.Reload), null, onMacroReload);
+                menu.Items.Add(Language.GetString(LocString.Save), null, onMacroSave);
 
                 MacroAction a;
                 try
@@ -2960,69 +2956,67 @@ namespace Assistant
                 {
                     int pos = actionList.SelectedIndex;
 
-                    menu.MenuItems.Add("-");
+                    menu.Items.Add("-");
                     if (actionList.Items.Count > 1)
                     {
-                        menu.MenuItems.Add(Language.GetString(LocString.MoveUp), new EventHandler(OnMacroActionMoveUp));
+                        menu.Items.Add(Language.GetString(LocString.MoveUp), null, OnMacroActionMoveUp);
 
                         if (pos <= 0)
                         {
-                            menu.MenuItems[menu.MenuItems.Count - 1].Enabled = false;
+                            menu.Items[menu.Items.Count - 1].Enabled = false;
                         }
 
-                        menu.MenuItems.Add(Language.GetString(LocString.MoveDown),
-                            new EventHandler(OnMacroActionMoveDown));
+                        menu.Items.Add(Language.GetString(LocString.MoveDown), null, OnMacroActionMoveDown);
 
                         if (pos >= actionList.Items.Count - 1)
                         {
-                            menu.MenuItems[menu.MenuItems.Count - 1].Enabled = false;
+                            menu.Items[menu.Items.Count - 1].Enabled = false;
                         }
 
-                        menu.MenuItems.Add("-");
+                        menu.Items.Add("-");
                     }
 
-                    menu.MenuItems.Add("Copy Line", new EventHandler(onMacroCopyLine));
-                    menu.MenuItems.Add("Paste Line", new EventHandler(onMacroPasteLine));
+                    menu.Items.Add("Copy Line", null, onMacroCopyLine);
+                    menu.Items.Add("Paste Line", null, onMacroPasteLine);
 
-                    menu.MenuItems.Add(Language.GetString(LocString.RemAct), new EventHandler(onMacroActionDelete));
-                    menu.MenuItems.Add("-");
-                    menu.MenuItems.Add(Language.GetString(LocString.BeginRec), new EventHandler(onMacroBegRecHere));
-                    menu.MenuItems.Add(Language.GetString(LocString.PlayFromHere), new EventHandler(onMacroPlayHere));
+                    menu.Items.Add(Language.GetString(LocString.RemAct), null, onMacroActionDelete);
+                    menu.Items.Add("-");
+                    menu.Items.Add(Language.GetString(LocString.BeginRec), null, onMacroBegRecHere);
+                    menu.Items.Add(Language.GetString(LocString.PlayFromHere), null, onMacroPlayHere);
 
-                    MenuItem[] aMenus = a.GetContextMenuItems();
+                    ToolStripMenuItem[] aMenus = a.GetContextMenuItems();
                     if (aMenus != null && aMenus.Length > 0)
                     {
-                        menu.MenuItems.Add("-");
-                        menu.MenuItems.AddRange(aMenus);
+                        menu.Items.Add("-");
+                        menu.Items.AddRange(aMenus);
                     }
                 }
 
-                menu.MenuItems.Add("-");
+                menu.Items.Add("-");
 
-                menu.MenuItems.Add(Language.GetString(LocString.Constructs), new MenuItem[]
-                {
-                    new MenuItem(Language.GetString(LocString.InsWait), new EventHandler(onMacroInsPause)),
-                    new MenuItem(Language.GetString(LocString.InsLT), new EventHandler(onMacroInsertSetLT)),
-                    new MenuItem(Language.GetString(LocString.InsComment), new EventHandler(onMacroInsertComment)),
-                    new MenuItem(Language.GetString(LocString.InsertOverheadMessage),
-                        new EventHandler(onMacroInsertOverheadMessage)),
-                    new MenuItem(Language.GetString(LocString.InsertWaitForTarget),
-                        new EventHandler(onMacroInsertWaitForTarget)),
-                    new MenuItem(Language.GetString(LocString.InsertClearSysMsg), new EventHandler(onMacroInsertClearSysMsg)),
-                    new MenuItem("-"),
-                    new MenuItem(Language.GetString(LocString.InsIF), new EventHandler(onMacroInsertIf)),
-                    new MenuItem(Language.GetString(LocString.InsELSE), new EventHandler(onMacroInsertElse)),
-                    new MenuItem(Language.GetString(LocString.InsENDIF), new EventHandler(onMacroInsertEndIf)),
-                    new MenuItem("-"),
-                    new MenuItem(Language.GetString(LocString.InsFOR), new EventHandler(onMacroInsertFor)),
-                    new MenuItem(Language.GetString(LocString.InsENDFOR), new EventHandler(onMacroInsertEndFor)),
-                    new MenuItem("-"),
-                    new MenuItem(Language.GetString(LocString.InsertWhile), new EventHandler(onMacroInsertWhile)),
-                    new MenuItem(Language.GetString(LocString.InsertEndWhile), new EventHandler(onMacroInsertEndWhile)),
-                    new MenuItem("-"),
-                    new MenuItem(Language.GetString(LocString.InsertDo), new EventHandler(onMacroInsertDo)),
-                    new MenuItem(Language.GetString(LocString.InsertDoWhile), new EventHandler(onMacroInsertDoWhile)),
-                });
+                ToolStripMenuItem submenu = new ToolStripMenuItem(Language.GetString(LocString.Constructs));
+
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsWait), null, onMacroInsPause);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsLT), null, onMacroInsertSetLT);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsComment), null, onMacroInsertComment);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertOverheadMessage), null, onMacroInsertOverheadMessage);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertWaitForTarget), null, onMacroInsertWaitForTarget);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertClearSysMsg), null, onMacroInsertClearSysMsg);
+                submenu.DropDownItems.Add("-");
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsIF), null, onMacroInsertIf);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsELSE), null, onMacroInsertElse);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsENDIF), null, onMacroInsertEndIf);
+                submenu.DropDownItems.Add("-");
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsFOR), null, onMacroInsertFor);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsENDFOR), null, onMacroInsertEndFor);
+                submenu.DropDownItems.Add("-");
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertWhile), null, onMacroInsertWhile);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertEndWhile), null, onMacroInsertEndWhile);
+                submenu.DropDownItems.Add("-");
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertDo), null, onMacroInsertDo);
+                submenu.DropDownItems.Add(Language.GetString(LocString.InsertDoWhile), null, onMacroInsertDoWhile);
+
+                menu.Items.Add(submenu);
 
                 menu.Show(actionList, new Point(e.X, e.Y));
             }
@@ -3044,7 +3038,7 @@ namespace Assistant
                 if (a == null)
                     return;
 
-                MenuItem[] aMenus = a.GetContextMenuItems();
+                ToolStripMenuItem[] aMenus = a.GetContextMenuItems();
 
                 if (aMenus != null && aMenus.Length > 0)
                 {
@@ -3183,7 +3177,7 @@ namespace Assistant
             if (a >= m.Actions.Count) // -1 is valid, will insert @ top
                 return;
 
-            MenuItem mnu = (MenuItem) sender;
+            ToolStripMenuItem mnu = (ToolStripMenuItem) sender;
 
             m.Actions.Insert(a + 1, new SetMacroVariableTargetAction(mnu.Text));
             RedrawActionList(m);
@@ -3648,14 +3642,14 @@ namespace Assistant
         {
             if (e.Button == MouseButtons.Right && e.Clicks == 1)
             {
-                ContextMenu menu = new ContextMenu();
+                ContextMenuStrip menu = new ContextMenuStrip();
                
-                menu.MenuItems.Add("Delete", new EventHandler(DeleteScreenCap));
+                menu.Items.Add("Delete", null, DeleteScreenCap);
 
                 if (screensList.SelectedIndex == -1)
-                    menu.MenuItems[menu.MenuItems.Count - 1].Enabled = false;
+                    menu.Items[menu.Items.Count - 1].Enabled = false;
 
-                menu.MenuItems.Add("Delete ALL", new EventHandler(ClearScreensDirectory));
+                menu.Items.Add("Delete ALL", null, ClearScreensDirectory);
 
 
                 menu.Show(screensList, new Point(e.X, e.Y));
@@ -4834,11 +4828,11 @@ namespace Assistant
 
             //if (e.Button == MouseButtons.Right && e.Clicks == 1)
             //{
-            //    ContextMenu menu = new ContextMenu();
-            //    //menu.MenuItems.Add(Language.GetString(LocString.Reload), new EventHandler(onMacroReload));
-            //    menu.MenuItems.Add("Import (Copy from clipboard)", new EventHandler(OnAgentImport));
+            //    ContextMenuStrip menu = new ContextMenuStrip();
+            //    //menu.MenuItems.Add(Language.GetString(LocString.Reload), onMacroReload);
+            //    menu.MenuItems.Add("Import (Copy from clipboard)", OnAgentImport);
             //    menu.MenuItems.Add("-");
-            //    menu.MenuItems.Add("Export (Copy to clipboard)", new EventHandler(OnAgentExport));
+            //    menu.MenuItems.Add("Export (Copy to clipboard)", OnAgentExport);
 
             //    menu.Show(agentSubList, new Point(e.X, e.Y));
             //}
@@ -5525,11 +5519,11 @@ namespace Assistant
 
             if ((e.Button & MouseButtons.Right) != 0)
             {
-                ContextMenu menu = new ContextMenu();
-                menu.MenuItems.Add(Language.GetString(LocString.AddAllMobileFriends),
-                    new EventHandler(onAddAllMobilesAsFriends));
-                menu.MenuItems.Add(Language.GetString(LocString.AddAllHumanoidsAsFriends),
-                    new EventHandler(onAddAllHumanoidsAsFriends));
+                ContextMenuStrip menu = new ContextMenuStrip();
+                menu.Items.Add(Language.GetString(LocString.AddAllMobileFriends), null,
+                    onAddAllMobilesAsFriends);
+                menu.Items.Add(Language.GetString(LocString.AddAllHumanoidsAsFriends), null,
+                    onAddAllHumanoidsAsFriends);
 
                 menu.Show(friendAddTarget, new Point(e.X, e.Y));
             }
@@ -5582,9 +5576,9 @@ namespace Assistant
 
             if (e.Button == MouseButtons.Right)
             {
-                ContextMenu menu = new ContextMenu();
-                menu.MenuItems.Add("Import 'Friends' from clipboard", new EventHandler(onImportFriends));
-                menu.MenuItems.Add("Export 'Friends' to clipboard", new EventHandler(onExportFriends));
+                ContextMenuStrip menu = new ContextMenuStrip();
+                menu.Items.Add("Import 'Friends' from clipboard", null, onImportFriends);
+                menu.Items.Add("Export 'Friends' to clipboard", null, onExportFriends);
 
                 menu.Show(friendsList, new Point(e.X, e.Y));
             }
@@ -6337,17 +6331,17 @@ namespace Assistant
         {
             if (e.Button == MouseButtons.Right && e.Clicks == 1)
             {
-                ContextMenu menu = new ContextMenu();
+                ContextMenuStrip menu = new ContextMenuStrip();
 
                 if (!string.IsNullOrEmpty(scriptEditor.SelectedText))
                 {
-                    menu.MenuItems.Add("Comment", OnScriptComment);
-                    menu.MenuItems.Add("Uncomment", OnScriptUncomment);
+                    menu.Items.Add("Comment", null, OnScriptComment);
+                    menu.Items.Add("Uncomment", null, OnScriptUncomment);
 
                     if (!string.IsNullOrEmpty(scriptEditor.SelectedText) && !ScriptManager.Running && !ScriptManager.Recording && World.Player != null)
                     {
-                        menu.MenuItems.Add("-");
-                        menu.MenuItems.Add("Play selected script code", OnScriptPlaySelected);
+                        menu.Items.Add("-");
+                        menu.Items.Add("Play selected script code", null, OnScriptPlaySelected);
 
                         int space = scriptEditor.SelectedText.IndexOf(" ", StringComparison.Ordinal);
 
@@ -6357,17 +6351,18 @@ namespace Assistant
 
                             if (command.Equals("dclick"))
                             {
-                                menu.MenuItems.Add("-");
-                                menu.MenuItems.Add("Convert to 'dclicktype' by gfxid", OnScriptDclickTypeId);
-                                menu.MenuItems.Add("Convert to 'dclicktype' by name", OnScriptDclickTypeName);
+                                menu.Items.Add("-");
+                                menu.Items.Add("Convert to 'dclicktype' by gfxid", null, OnScriptDclickTypeId);
+                                menu.Items.Add("Convert to 'dclicktype' by name", null, OnScriptDclickTypeName);
                             }
                         }
                     }
 
-                    menu.MenuItems.Add("-");
+                    menu.Items.Add("-");
                 }
 
-                menu.MenuItems.Add(scriptSplitContainer.Panel1Collapsed ? "Show script tree" : "Hide script tree",
+                menu.Items.Add(scriptSplitContainer.Panel1Collapsed ? "Show script tree" : "Hide script tree",
+                    null,
                     OnScriptHideTreeView);
 
                 menu.Show(scriptEditor, new Point(e.X, e.Y));
@@ -6641,11 +6636,11 @@ namespace Assistant
         {
             if (e.Button == MouseButtons.Right && e.Clicks == 1)
             {
-                ContextMenu menu = new ContextMenu();
-                menu.MenuItems.Add("Import Waypoints", onImportWaypoints);
-                menu.MenuItems.Add("Export Waypoints", onExportWaypoints);
-                menu.MenuItems.Add("-");
-                menu.MenuItems.Add("Clear All Waypoints", onClearWaypoints);
+                ContextMenuStrip menu = new ContextMenuStrip();
+                menu.Items.Add("Import Waypoints", null, onImportWaypoints);
+                menu.Items.Add("Export Waypoints", null, onExportWaypoints);
+                menu.Items.Add("-");
+                menu.Items.Add("Clear All Waypoints", null, onClearWaypoints);
 
                 menu.Show(waypointList, new Point(e.X, e.Y));
             }


### PR DESCRIPTION
Things like MenuStrip are deprecated and have more modern replacements.
The replacements work on .net framework and .net core, so no need
to upgrade to .net core at this time.