### PR TITLE
Highlight the line that is currently executing in the script editor

### DIFF
--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -6044,7 +6044,7 @@ namespace Assistant
             if (scriptList.SelectedIndex < 0)
                 return;
 
-            ScriptManager.ClearHighlightLine();
+            ScriptManager.ClearAllHighlightLines();
 
             ScriptManager.RazorScript script = (ScriptManager.RazorScript) scriptList.SelectedItem;
 


### PR DESCRIPTION
This change allows you to see which line is currently executing in the script editor.

As part of this, I added some code for tracking different "types" of highlights - for now it includes the existing Error (red background) and the new Executing line (in blue). It could be useful in the future to provide other types of highlights.