### PR TITLE
Fix for infinite loop when using nested "for" loops in scripts

### DIFF
--- a/Razor/Scripts/Engine/Interpreter.cs
+++ b/Razor/Scripts/Engine/Interpreter.cs
@@ -628,13 +628,24 @@ namespace Assistant.Scripts.Engine
                     // Walk backward to the for statement
                     _statement = _statement.Prev();
 
+                    // track depth in case there is a nested for
+                    depth = 0;
+
                     while (_statement != null)
                     {
                         node = _statement.FirstChild();
 
-                        if (node.Type == ASTNodeType.FOR)
+                        if (node.Type == ASTNodeType.ENDFOR)
                         {
-                            break;
+                            depth++;
+                        }
+                        else if (node.Type == ASTNodeType.FOR)
+                        {
+                            if (depth == 0)
+                            {
+                                break;
+                            }
+                            depth--;
                         }
 
                         _statement = _statement.Prev();


### PR DESCRIPTION
When the interpreter evaluates an ENDFOR node it searches backward for it's corresponding FOR node. This change keeps track of depth so the correct FOR node is found.

Fixes #128 