### PR TITLE
Improve linux hotkey handling

### DIFF
--- a/Razor/HotKeys/HotKeys.cs
+++ b/Razor/HotKeys/HotKeys.cs
@@ -687,18 +687,13 @@ namespace Assistant
                     {
                         if (hk.Key == key)
                         {
-                            // Force a keycheck using the platform-specific code.
-                            // If running on a non-windows OS, we can't trust the keycode received as key.
-                            if (KeyDown ((Keys) hk.Key))
-                            {
-                                if (Macros.MacroManager.AcceptActions)
-                                    Macros.MacroManager.Action(new Macros.HotKeyAction(hk));
+                            if (Macros.MacroManager.AcceptActions)
+                                Macros.MacroManager.Action(new Macros.HotKeyAction(hk));
 
-                                ScriptManager.AddToScript($"hotkey '{hk.DispName}'");
+                            ScriptManager.AddToScript($"hotkey '{hk.DispName}'");
 
-                                hk.Callback();
-                                return hk.SendToUO;
-                            }
+                            hk.Callback();
+                            return hk.SendToUO;
                         }
                     }
                 }

--- a/Razor/HotKeys/HotKeys.cs
+++ b/Razor/HotKeys/HotKeys.cs
@@ -687,13 +687,18 @@ namespace Assistant
                     {
                         if (hk.Key == key)
                         {
-                            if (Macros.MacroManager.AcceptActions)
-                                Macros.MacroManager.Action(new Macros.HotKeyAction(hk));
+                            // Force a keycheck using the platform-specific code.
+                            // If running on a non-windows OS, we can't trust the keycode received as key.
+                            if (KeyDown ((Keys) hk.Key))
+                            {
+                                if (Macros.MacroManager.AcceptActions)
+                                    Macros.MacroManager.Action(new Macros.HotKeyAction(hk));
 
-                            ScriptManager.AddToScript($"hotkey '{hk.DispName}'");
+                                ScriptManager.AddToScript($"hotkey '{hk.DispName}'");
 
-                            hk.Callback();
-                            return hk.SendToUO;
+                                hk.Callback();
+                                return hk.SendToUO;
+                            }
                         }
                     }
                 }

--- a/Razor/Platform.cs
+++ b/Razor/Platform.cs
@@ -230,24 +230,37 @@ namespace Assistant
             XRaiseWindow(Display, window);
         }
         
-        // This list is by no means complete.
+        /* List of mappings between:
+         * Windows 'Virtual Key Codes' (https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
+         * and
+         * Unix X11 Keysyms (https://cgit.freedesktop.org/xorg/proto/x11proto/tree/keysymdef.h)
+         *
+         * Testing was done on Gentoo Linux with an Unicomp New Model M, standard ANSI 104-key layout. (https://www.pckeyboard.com/page/product/NEW_M)
+         * The keyboard used may affect the results for some of the more ambiguous keysyms and keycodes. Hopefully this works for most folks.
+         */
         static Dictionary<int, int> m_MapX11Key = new Dictionary<int, int>()
         {
+            // Utility keys.
+            // For many of these, Windows lists one keycode while unix has a separate keysym for each symbol on the key.
+            // In such cases, the primary symbol is used for the mapping.
             {0x08, 0xFF08}, // Backspace
             {0x09, 0xFF09}, // Tab
             {0x0C, 0xFF0B}, // Clear
             {0x0D, 0xFF0D}, // Return
-            
-            //{0x10, 0xFF??}, // Shift
-            //{0x11, 0xFF??}, // Control
-            //{0x12, 0xFF??}, // Alt
-                
+            {0x20, 0x0020}, // Space
+            {0xDE, 0x0027}, // Single/Double quote key
+            {0xDB, 0x005B}, // Bracket left
+            {0xDD, 0x005D}, // Bracket right
+            {0xBC, 0x002C}, // Comma / Less than (<)
+            {0xBE, 0x002E}, // Period / Greater than (>)
+            {0xDC, 0x005C}, // Backslash
+            {0xBB, 0x003D}, // Addition / Equals
+            {0xBF, 0x002F}, // Forward slash
+            {0xBD, 0x002D}, // Dash / Minus
+            {0xC0, 0x0060}, // Grave / Tilde
+            {0xBA, 0x003B}, // Semi-Colon / Colon
             {0x13, 0xFF13}, // Pause
             {0x1B, 0xFF1B}, // Escape
-            {0x91, 0xFF14}, // Scroll Lock
-            {0x14, 0xFFE5}, // Caps Lock
-            //{0x91, 0xFF15}, // SysRq
-
             {0x26, 0xFF52}, // Up arrow
             {0x28, 0xFF54}, // Down arrow
             {0x25, 0xFF51}, // Left arrow
@@ -258,11 +271,29 @@ namespace Assistant
             {0x23, 0xFF57}, // End
             {0x21, 0xFF55}, // Page Up
             {0x22, 0xFF56}, // Page Down
-            
-            
-            // Keypad
+            {0x14, 0xFFE5}, // Caps Lock
+            {0x91, 0xFF14}, // Scroll Lock
+            // Same physical key as scroll lock, unlikely to be needed for UO
+            //{0x91, 0xFF15}, // SysRq
+
+            // Modifier keys
+            // Unix has no combined keysym for these, handled separately in GetAsyncKeyState() below.
+            //{0x10, 0xFF??}, // Shift
+            //{0x11, 0xFF??}, // Control
+            //{0x12, 0xFF??}, // Alt
+            {0xA0, 0xFFE1}, // LSHIFT
+            {0xA1, 0xFFE2}, // RSHIFT
+            {0xA2, 0xFFE3}, // LCONTROL
+            {0xA3, 0xFFE4}, // RCONTROL
+            {0xA4, 0xFFE9}, // LALT
+            {0xA5, 0xFFEA}, // RALT
+            // These are pretty ambiguous and I don't have a windows machine handy to verify them.
+            //{0x5B, 0x00EB}, // Super L / Windows key L
+            //{0x5C, 0x00EC}, // Super R / Windows key R
+            //{0x5D, 0x0067}, // Menu
+
+            // Numeric Keypad
             {0x90, 0xFFBE}, // Num lock
-            
             {0x60, 0xFFB0}, // Numpad0
             {0x61, 0xFFB1},
             {0x62, 0xFFB2},
@@ -273,8 +304,13 @@ namespace Assistant
             {0x67, 0xFFB7},
             {0x68, 0xFFB8},
             {0x69, 0xFFB0}, // Numpad9
-
-            
+            {0x6F, 0xFFAF}, // Divide
+            {0x6A, 0xFFAA}, // Multiply
+            {0x6D, 0xFFAD}, // Subtract
+            {0x6B, 0xFFAB}, // Add
+            {0x6C, 0xFFAE}, // Decimal
+            // Windows has no separate keycode for these, so ignore them for now.
+            // Should probably be handled similar to how Shift/Control/Alt are, below.
             //{0x, 0xFF95}, // KP_Home
             //{0x, 0xFF97}, // KP_Up
             //{0x, 0xFF9A}, // KP_PageUp
@@ -283,16 +319,7 @@ namespace Assistant
             //{0x, 0xFF9C}, // KP_End
             //{0x, 0xFF99}, // KP_Down
             //{0x, 0xFF9B}, // KP_PageDown
-
-            
-            {0x6F, 0xFFAF}, // Divide
-            {0x6A, 0xFFAA}, // Multiply
-            {0x6D, 0xFFAD}, // Subtract
-            {0x6B, 0xFFAB}, // Add
-            // Cannot remap the same key twice
-            // {0x0D, 0xFF8D}, // Enter
-            {0x6C, 0xFFAE}, // Decimal
-            
+            //{0x, 0xFF8D}, // KP_Enter
 
             // F1-F24
             {0x70, 0xFFBE},
@@ -320,23 +347,55 @@ namespace Assistant
             {0x86, 0xFFD4},
             {0x87, 0xFFD5},
 
-            // Modifiers
-            {0xA0, 0xFFE1}, // LSHIFT
-            {0xA1, 0xFFE2}, // RSHIFT
-            {0xA2, 0xFFE3}, // LCONTROL
-            {0xA3, 0xFFE4}, // RCONTROL
-            {0xA4, 0xFFE9}, // LALT
-            {0xA5, 0xFFEA}, // RALT
+            // 0-9 map directly
+            {0x30, 0x0030},
+            {0x31, 0x0031},
+            {0x32, 0x0032},
+            {0x33, 0x0033},
+            {0x34, 0x0034},
+            {0x35, 0x0035},
+            {0x36, 0x0036},
+            {0x37, 0x0037},
+            {0x38, 0x0038},
+            {0x39, 0x0039},
 
-            // 0-9, Capital A-Z map directly
-            // Windows will never pass lowercase A-Z
-            
+            // Captial A-Z map directly.
+            {0x41, 0x0041},
+            {0x42, 0x0042},
+            {0x43, 0x0043},
+            {0x44, 0x0044},
+            {0x45, 0x0045},
+            {0x46, 0x0046},
+            {0x47, 0x0047},
+            {0x48, 0x0048},
+            {0x49, 0x0049},
+            {0x4A, 0x004A},
+            {0x4B, 0x004B},
+            {0x4C, 0x004C},
+            {0x4D, 0x004D},
+            {0x4E, 0x004E},
+            {0x4F, 0x004F},
+            {0x50, 0x0050},
+            {0x51, 0x0051},
+            {0x52, 0x0052},
+            {0x53, 0x0053},
+            {0x54, 0x0054},
+            {0x55, 0x0055},
+            {0x56, 0x0056},
+            {0x57, 0x0057},
+            {0x58, 0x0058},
+            {0x59, 0x0059},
+            {0x5A, 0x005A},
+
+            // Windows doesn't have lowercase A-Z keycodes.
         };
         
         internal static int MapX11Key(int key)
         {
             int keycode;
 
+            // If no mapping is found, pass the unmapped code back out.
+            // Can't be any worse than the way it used to work.
             if (!m_MapX11Key.TryGetValue(key, out keycode))
                 keycode = key;
 
@@ -350,27 +409,28 @@ namespace Assistant
             try
             {
                 int key = 0; int key2 = 0;
-                
-                // Code elsewhere distills R/L mod keys to Window's single keycode. Un-distill them here
-                if (winkey == 0x10)      { key = 0xFFE1; key2 = 0xFFE2; } // Any shift key
-                else if (winkey == 0x11) { key = 0xFFE3; key2 = 0xFFE4; } // Any ctrl key
-                else if (winkey == 0x12) { key = 0xFFE9; key2 = 0xFFEA; } // Any alt key
-                else                     { key = LinuxPlatform.MapX11Key (winkey); }
+                bool pressed = false; bool pressed2 = false;
+
+                // Convert Windows Virtual Key Code to an X11 Keysym.
+                // Code elsewhere distills Left/Right modifier keys to Window's single keycode. Un-distill them here
+                if (winkey == 0x10)      { key = 0xFFE1; key2 = 0xFFE2; }               // Any shift key
+                else if (winkey == 0x11) { key = 0xFFE3; key2 = 0xFFE4; }               // Any ctrl key
+                else if (winkey == 0x12) { key = 0xFFE9; key2 = 0xFFEA; }               // Any alt key
+                else                     { key = LinuxPlatform.MapX11Key (winkey); }    // Any other key, map the keycode to a keysym
 
                 // Get physical keyboard state - every key being pressed is listed in the byte array
                 var szKey = new byte[32];
                 int res = XQueryKeymap(Display, szKey);
 
-                // Convert physical keypress to X11 keycode
+                // Convert X11 Keysym to X11 Keycode
                 int code = XKeysymToKeycode(Display, (int) key);
 
                 // Check if keycode is included in the keyboard state.
                 var r = szKey[code / 8];
                 var s = (1 << (code % 8));
-                bool pressed = Convert.ToBoolean(r & s);
+                pressed = Convert.ToBoolean(r & s);
 
                 // Check the second modifier key if required
-                bool pressed2 = false;
                 if (key2 > 0)
                 {
                     int code2 = XKeysymToKeycode(Display, (int) key2);


### PR DESCRIPTION
These two patches address some incorrect-key-triggering-hotkey problems when running with ClassicUO on Linux, as reported in #153 

I've added another Dictionary for mapping Windows Virtual Key Codes to Unix X11 Keysyms, and improved the key-pressed detection used when the platform is detected as linux.

I've been playing the game with these changes, and haven't found any problems with them. At worst, it shouldn't work any worse than the way it used to, since if it sees a keycode that doesn't have a mapping, it'll pass it through unchanged.