### PR TITLE
Save global settings to a simple csv file

### DIFF
--- a/Razor/Client/OSI.cs
+++ b/Razor/Client/OSI.cs
@@ -903,7 +903,7 @@ namespace Assistant
 
         public override string GetUoFilePath()
         {
-            return ConfigurationManager.AppSettings["UODataDir"];
+            return Config.GetAppSetting<string>("UODataDir");
         }
 
         public override IntPtr GetWindowHandle()

--- a/Razor/UI/Config.cs
+++ b/Razor/UI/Config.cs
@@ -292,7 +292,11 @@ namespace Assistant
             AddProperty("AutoSaveScriptPlay", false);
 
             AddProperty("HighlightFriend", false);
-            
+
+            AddProperty("ScriptTargetTypeRange", false);
+            AddProperty("ScriptDClickTypeRange", false);
+            AddProperty("ScriptFindTypeRange", false);
+
             AddProperty("ScriptDisablePlayFinish", false);
 
             AddProperty("ShowWaypointOverhead", true);
@@ -702,6 +706,53 @@ namespace Assistant
         private static Profile m_Current;
         private static Dictionary<Serial, string> m_Chars;
 
+        private static Dictionary<string, string> m_AppSettings = new Dictionary<string, string>();
+
+        static Config()
+        {
+            var path = Path.Combine(Engine.RootPath, "settings.csv");
+
+            // Set defaults
+            m_AppSettings["UODataDir"] = @"D:\Games\UO";
+            m_AppSettings["UOClient"] = @"D:\Games\UO\client.exe";
+            m_AppSettings["LastPort"] = "2593";
+            m_AppSettings["LastProfile"] = "default";
+            m_AppSettings["LastServer"] = "127.0.0.1";
+            m_AppSettings["LastServerId"] = "0";
+            m_AppSettings["ClientEncrypted"] = "1";
+            m_AppSettings["ServerEncrypted"] = "0";
+            m_AppSettings["ShowWelcome"] = "1";
+            m_AppSettings["UId"] = "21613fcd";
+            m_AppSettings["MaxOrganizerAgents"] = "20";
+            m_AppSettings["MaxBuyAgents"] = "10";
+            m_AppSettings["MaxRestockAgents"] = "10";
+            m_AppSettings["ImportProfilesAndMacros"] = "true";
+            m_AppSettings["BackupPath"] = @".\Backup";
+
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    File.Create(path);
+                }
+                else
+                {
+                    foreach (var line in File.ReadLines(path))
+                    {
+                        var strs = line.Split(',');
+
+                        m_AppSettings[strs[0].Trim()] = strs[1].Trim();
+                    }
+                }
+            }
+            catch (Exception)
+            { }
+            finally
+            {
+                SaveAppSettings();
+            }
+        }
+
         public static Profile CurrentProfile
         {
             get
@@ -717,6 +768,7 @@ namespace Assistant
             if (m_Current != null)
                 m_Current.Save();
             SaveCharList();
+            SaveAppSettings();
         }
 
         public static bool LoadProfile(string name)
@@ -907,11 +959,31 @@ namespace Assistant
             return list;
         }
 
+        private static void SaveAppSettings()
+        {
+            var path = Path.Combine(Engine.RootPath, "settings.csv");
+
+            Engine.EnsureDirectory(Engine.RootPath);
+
+            if (!File.Exists(path))
+            {
+                File.Create(path);
+            }
+
+            var data = "";
+            foreach (var setting in m_AppSettings)
+            {
+                data += $"{setting.Key}, {setting.Value}\n";
+            }
+
+            File.WriteAllText(path, data);
+        }
+
         public static T GetAppSetting<T>(string key)
         {
             try
             {
-                var appSetting = ConfigurationManager.AppSettings[key];
+                var appSetting = m_AppSettings[key];
 
                 if (!string.IsNullOrWhiteSpace(appSetting))
                 {
@@ -966,13 +1038,8 @@ namespace Assistant
         {
             try
             {
-                Configuration config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-                config.AppSettings.Settings.Remove(key);
-                config.AppSettings.Settings.Add(key, value);
-
-                config.Save(ConfigurationSaveMode.Modified, true);
-
-                ConfigurationManager.RefreshSection("appSettings");
+                m_AppSettings[key] = value;
+                SaveAppSettings();
 
                 return true;
             }

--- a/Razor/UltimaSDK/Files.cs
+++ b/Razor/UltimaSDK/Files.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using Assistant;
 using Microsoft.Win32;
 
 namespace Ultima
@@ -338,7 +339,7 @@ namespace Ultima
 
         private static string LoadDirectory()
         {
-            string dir = ConfigurationManager.AppSettings["UODataDir"];
+            string dir = Config.GetAppSetting<string>("UODataDir");
 
             // If they're using the ClassicUO client, pull the UO data dir from the plugin
             if (!Assistant.Client.IsOSI)


### PR DESCRIPTION
Stop using the ConfigurationManager because that file changes when the
program is run. This makes it difficult for launchers to ship good
settings files.