### PR TITLE
Make Razor work with the OSI client again

### DIFF
--- a/Crypt/Crypt.cpp
+++ b/Crypt/Crypt.cpp
@@ -1628,6 +1628,16 @@ void MessageProc( HWND hWnd, UINT nMsg, WPARAM wParam, LPARAM lParam, MSG *pMsg 
 
 		InitThemes();
 
+		if (pShared)
+		{
+			pShared->AllowNegotiate = (wParam & 0x04) != 0;
+
+			pShared->UOVersion[0] = 0;
+
+			if (NativeGetUOVersion != NULL)
+				strncpy(pShared->UOVersion, NativeGetUOVersion(), 16);
+		}
+
 		if ( !pShared )
 			PostMessage( hRazorWnd, WM_UONETEVENT, NOT_READY, NO_SHAREMEM );
 		else if ( CopyFailed )
@@ -1636,16 +1646,6 @@ void MessageProc( HWND hWnd, UINT nMsg, WPARAM wParam, LPARAM lParam, MSG *pMsg 
 			PostMessage( hRazorWnd, WM_UONETEVENT, NOT_READY, NO_PATCH );
 		else
 			PostMessage( hRazorWnd, WM_UONETEVENT, READY, SUCCESS );
-
-		if ( pShared )
-		{
-			pShared->AllowNegotiate = (wParam & 0x04) != 0;
-
-			pShared->UOVersion[0] = 0;
-
-			if ( NativeGetUOVersion != NULL )
-				strncpy( pShared->UOVersion, NativeGetUOVersion(), 16 );
-		}
 
 		/* Start a timer that will call a callback each tick. We use this to implement
 		 * timers as well as scan client memory for position updates. */

--- a/Razor/Client/OSI.cs
+++ b/Razor/Client/OSI.cs
@@ -122,7 +122,7 @@ namespace Assistant
         private static unsafe extern void SetServer(uint ip, ushort port);
 
         [DllImport("Crypt.dll")]
-        internal static unsafe extern string GetUOVersion();
+        internal static unsafe extern IntPtr GetUOVersion();
 
         [DllImport("Loader.dll")]
         private static unsafe extern uint Load(string exe, string dll, string func, void* dllData, int dataLen,
@@ -898,7 +898,7 @@ namespace Assistant
 
         public override string GetClientVersion()
         {
-            return GetUOVersion();
+            return Marshal.PtrToStringAnsi(GetUOVersion());
         }
 
         public override string GetUoFilePath()

--- a/Razor/Core/Main.cs
+++ b/Razor/Core/Main.cs
@@ -330,8 +330,6 @@ namespace Assistant
                 return;
             }
 
-            Ultima.Multis.PostHSFormat = UsePostHSChanges;
-
             string addr = Config.GetAppSetting<string>("LastServer");
             int port = Config.GetAppSetting<int>("LastPort");
 


### PR DESCRIPTION
The string here is a char* in shared memory. C# assumes all memory returned to it was allocated by AllocHGlobal when doing default marshalling, so this crashes. It must have worked on earlier .net simply on accident.

Also the UsePostHSChanges can't be called until crypt is fully initialized. It's already called later on, so just delete the place where it is used too early.