### PR TITLE
Script editor autocomplete tooltip fix for mono

### DIFF
--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Drawing;
@@ -457,7 +457,6 @@ namespace FastColoredTextBoxNS
                 if (foundSelected)
                 {
                     AdjustScroll();
-                    DoSelectedVisible();
                 }
             }
 
@@ -767,7 +766,6 @@ namespace FastColoredTextBoxNS
         {
             FocussedItemIndex = Math.Max(0, Math.Min(FocussedItemIndex + shift, visibleItems.Count - 1));
             DoSelectedVisible();
-            //
             Invalidate();
         }
 
@@ -812,15 +810,11 @@ namespace FastColoredTextBoxNS
                 var location = new Point(Right + 3 + Menu.Left, Menu.Top);
 
                 if (string.IsNullOrEmpty(text))
-                {
                     toolTip.ToolTipTitle = null;
-                    toolTip.Show(title, window, location.X, location.Y, ToolTipDuration);
-                }
                 else
-                {
                     toolTip.ToolTipTitle = title;
-                    toolTip.Show(text, window, location.X, location.Y, ToolTipDuration);
-                }
+
+                toolTip.Show(text, window, location.X, location.Y, ToolTipDuration);
             }
         }
 


### PR DESCRIPTION
This commit resolves the problem reported in issue #133, and without affecting tooltip behaviour on windows, that I can tell. Tested on Gentoo Linux w/ Mono 6.12.0.122 and Windows 10 w/.. whatever windows 10 ships with. No more crashes, and tooltips work in the script editor.

While the project maintainer in me is both in awe and a little jealous of anyone who actually plays the BOFH no-service-therefore-no-denial card and gets away with it, the problem irritated me enough to dig in to it and find another solution.

Give this a test and see if it works on your end.