### PR TITLE
FastColoredTextBox: Fix 'n' under mono.

### DIFF
--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -619,10 +619,14 @@ namespace Assistant
             if (tabs == null)
                 return;
 
+            // UseMnemonic toggle is an ugly hack for github issue #177
             if (tabs.SelectedTab != scriptsTab)
             {
                 UpdateTitle();
+                newProfile.UseMnemonic = true;
             }
+            else
+                newProfile.UseMnemonic = false;
 
             if (tabs.SelectedTab == generalTab)
             {


### PR DESCRIPTION
'Fixes' issue #177.

Under mono, the mnemonic assigned to the general tab's new profile button is active even when the script editor has focus, so the 'n' key isn't passed to the editor at all. It doesn't trigger the button either, it seems to just disappear.

More information and several potential solutions are laid out in the issue, but the one implemented in this small patch simply disables the mnemonic on the button if the Script Editor tab is selected, and restores it once it's un-selected.

Tested under Gentoo Linux / Mono 6.12.0.122 and Windows 10, everything seems happy now.

It doesn't actually fix the problem, but it does make things work again.