### PR TITLE
Counters re-write and beefing up count expression

### DIFF
--- a/Razor/Core/Counters.cs
+++ b/Razor/Core/Counters.cs
@@ -732,10 +732,7 @@ namespace Assistant
         {
             foreach (var c in m_List)
             {
-                ushort hue = (ushort)((c.Hue == -1 || c.Hue == 0xFFFF) ? 0xFFFF : c.Hue);
-                var id = new CounterID(c.ItemID, hue);
-
-                if (changes.Changes.ContainsKey(id))
+                if (changes.Changes.ContainsKey(c.CounterID))
                 {
                     c.OnUpdate();
                 }

--- a/help/docs/guide/expressions.md
+++ b/help/docs/guide/expressions.md
@@ -16,13 +16,15 @@ The following operators are supported:
 
 ## count/counter
 
-- `count ('name of counted item')`
-- `counter ('name of counted item')`
+- `count ('name of counter')`
+- `counter ('name of counter')`
+- `count ('name of item') [hue]`
+- `count (graphicID) [hue]`
 
-Description: Used to get the current number of a specific counted item in Razor
-
-!!! note
-You must have a counter setup in `Display->Counters` before using this expression. [More info](../help/displaycounters.md#counters)
+Description: Used to get the current amount of a specific item in player's backpack.
+Omitting the hue argument will result in count of all items of the specified type regardless of their hue.
+The expression can be used either directly by item type and hue, or by referencing a named counter manually set up in the Counters tab.
+[More info](../help/displaycounters.md#counters)
 
 !!! example
 
@@ -31,6 +33,22 @@ You must have a counter setup in `Display->Counters` before using this expressio
         ```vim
         if count 'garlic' < 5
             say 'getting low on garlic'
+        endif
+        ```
+        
+    === "Counting runebooks"
+    
+        ```vim
+        if count 'spellbook' '1121' == 0
+            say 'no runebooks found!'
+        endif
+        ```
+        
+    === "Detecting fancy coins"
+
+        ```vim
+        if count 'gold coin' > count 'gold coin' 0
+            overhead 'woot woot fancy coins in the pack!'
         endif
         ```
 


### PR DESCRIPTION
* Counters now always track the whole backpack, since we traverse all items anyway in the counter code
* Besides the current form, the count expression has gained a couple of new forms, enabling one to get counts by item name/gfxID (similar to ```findtype```) and optional hue:
  * ```count 'spellbook' 1121``` -- will match spellbooks with hue 1121
  * ```count '3821'``` -- will count coins regardless of hue