### PR TITLE
mobileIncoming item id rang check

### DIFF
--- a/Razor/Network/Packets.cs
+++ b/Razor/Network/Packets.cs
@@ -958,7 +958,7 @@ namespace Assistant
             {
                 Item item = (Item) m.Contains[i];
 
-                int itemID = item.ItemID & 0x3FFF;
+                int itemID = item.ItemID;
                 bool writeHue = (item.Hue != 0);
                 if (writeHue || isLT)
                     itemID |= 0x8000;


### PR DESCRIPTION
I don't know if other servesr can get that problem, but when they have itemId larger then 0x3FFF they will be wrongly displayed
so after Set Target Hotkey and when user habe SetTargetHighlight options on, target will be naked 