### PR TITLE
Extended text filter functionality to allow precise filtering of speech, Razor overhead messages and sys messages

### DIFF
--- a/Razor/Core/Mobile.cs
+++ b/Razor/Core/Mobile.cs
@@ -598,8 +598,7 @@ namespace Assistant
 
         internal void OverheadMessageFrom(int hue, string from, string text, bool ascii)
         {
-
-            if (TextFilterManager.IsOverheadFiltered(text))
+            if (TextFilterManager.IsOverheadFiltered(text) != SysMessageFilterResult.Allow)
             {
                 return;
             }

--- a/Razor/Core/Mobile.cs
+++ b/Razor/Core/Mobile.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text;
 using Assistant.Agents;
+using Assistant.Core;
 using Assistant.UI;
 
 namespace Assistant
@@ -597,6 +598,12 @@ namespace Assistant
 
         internal void OverheadMessageFrom(int hue, string from, string text, bool ascii)
         {
+
+            if (TextFilterManager.IsOverheadFiltered(text))
+            {
+                return;
+            }
+
             if (Config.GetBool("FilterOverheadMessages"))
             {
                 if (!MessageQueue.Enqueue(this, hue, "O", text))

--- a/Razor/Core/Mobile.cs
+++ b/Razor/Core/Mobile.cs
@@ -598,7 +598,7 @@ namespace Assistant
 
         internal void OverheadMessageFrom(int hue, string from, string text, bool ascii)
         {
-            if (TextFilterManager.IsOverheadFiltered(text) != SysMessageFilterResult.Allow)
+            if (TextFilterManager.IsTextFiltered(text, TextFilterType.Overhead) != TextFilterResult.Allow)
             {
                 return;
             }

--- a/Razor/Core/Player.cs
+++ b/Razor/Core/Player.cs
@@ -826,7 +826,11 @@ namespace Assistant
                         break;
                 }
 
-                SystemMessages.Add(text);
+                var filterResult = TextFilterManager.IsTextFiltered(text, TextFilterType.SysMessage);
+                if (filterResult != TextFilterResult.HideAndBlock)
+                    SystemMessages.Add(text);
+                if (filterResult != TextFilterResult.Allow)
+                    return;
 
                 if (Config.GetBool("FilterRazorMessages"))
                 {

--- a/Razor/Core/TextFilterManager.cs
+++ b/Razor/Core/TextFilterManager.cs
@@ -30,6 +30,13 @@ using Assistant.UI;
 
 namespace Assistant.Core
 {
+    public enum SysMessageFilterResult
+    {
+        Allow,
+        Hide,
+        HideAndBlock
+    }
+
     public class TextFilterEntryModel
     {
         public string Text { get; set; }
@@ -112,14 +119,14 @@ namespace Assistant.Core
             }
         }
 
-        public static bool IsFiltered(string text)
+        public static bool IsSpeechFiltered(string text)
         {
             if (!Config.GetBool("EnableTextFilter"))
                 return false;
 
             foreach (var entry in FilteredText)
             {
-                if (text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
+                if (entry.FilterSpeech && text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     return true;
                 }
@@ -127,6 +134,40 @@ namespace Assistant.Core
 
             return false;
         }
+
+        public static bool IsOverheadFiltered(string text)
+        {
+            if (!Config.GetBool("EnableTextFilter"))
+                return false;
+
+            foreach (var entry in FilteredText)
+            {
+                if (entry.FilterOverhead && text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static SysMessageFilterResult IsSysMessageFiltered(string text)
+        {
+            if (!Config.GetBool("EnableTextFilter"))
+                return SysMessageFilterResult.Allow;
+
+            foreach (var entry in FilteredText)
+            {
+                if (entry.FilterSysMessages && text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
+                {
+                    return entry.IgnoreFilteredMessageInScripts ? SysMessageFilterResult.HideAndBlock : SysMessageFilterResult.Hide;
+                }
+            }
+
+            return SysMessageFilterResult.Allow;
+        }
+
+        
 
         public static void Load(XmlElement node)
         {

--- a/Razor/Core/TextFilterManager.cs
+++ b/Razor/Core/TextFilterManager.cs
@@ -135,20 +135,22 @@ namespace Assistant.Core
             return false;
         }
 
-        public static bool IsOverheadFiltered(string text)
+        public static SysMessageFilterResult IsOverheadFiltered(string text)
         {
             if (!Config.GetBool("EnableTextFilter"))
-                return false;
+                return SysMessageFilterResult.Allow;
 
             foreach (var entry in FilteredText)
             {
                 if (entry.FilterOverhead && text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
                 {
-                    return true;
+                    return entry.IgnoreFilteredMessageInScripts
+                        ? SysMessageFilterResult.HideAndBlock
+                        : SysMessageFilterResult.Hide;
                 }
             }
 
-            return false;
+            return SysMessageFilterResult.Allow;
         }
 
         public static SysMessageFilterResult IsSysMessageFiltered(string text)
@@ -160,14 +162,15 @@ namespace Assistant.Core
             {
                 if (entry.FilterSysMessages && text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
                 {
-                    return entry.IgnoreFilteredMessageInScripts ? SysMessageFilterResult.HideAndBlock : SysMessageFilterResult.Hide;
+                    return entry.IgnoreFilteredMessageInScripts
+                        ? SysMessageFilterResult.HideAndBlock
+                        : SysMessageFilterResult.Hide;
                 }
             }
 
             return SysMessageFilterResult.Allow;
         }
 
-        
 
         public static void Load(XmlElement node)
         {

--- a/Razor/Core/TextFilterManager.cs
+++ b/Razor/Core/TextFilterManager.cs
@@ -20,13 +20,33 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Forms;
 using System.Xml;
+using System.Xml.Serialization;
 using Assistant.UI;
 
 namespace Assistant.Core
 {
+    public class TextFilterEntryModel
+    {
+        [XmlAttribute("text")]
+        public string Text { get; set; }
+        [DefaultValue(false)]
+        [XmlAttribute("sysmessages")]
+        public bool FilterSysMessages { get; set; }
+        [DefaultValue(false)]
+        [XmlAttribute("overhead")]
+        public bool FilterOverhead { get; set; }
+        [DefaultValue(true)]
+        [XmlAttribute("speech")]
+        public bool FilterSpeech { get; set; }
+        [DefaultValue(true)]
+        [XmlAttribute("ignoreinscripts")]
+        public bool IgnoreFilteredMessageInScripts { get; set; }
+    }
+
     public static class TextFilterManager
     {
         private static ListBox _filterTextList;

--- a/Razor/Core/TextFilterManager.cs
+++ b/Razor/Core/TextFilterManager.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 using System.Xml.Serialization;
@@ -29,56 +30,83 @@ using Assistant.UI;
 
 namespace Assistant.Core
 {
+    [XmlType("filter")]
     public class TextFilterEntryModel
     {
-        [XmlAttribute("text")]
-        public string Text { get; set; }
-        [DefaultValue(false)]
-        [XmlAttribute("sysmessages")]
-        public bool FilterSysMessages { get; set; }
-        [DefaultValue(false)]
-        [XmlAttribute("overhead")]
-        public bool FilterOverhead { get; set; }
-        [DefaultValue(true)]
-        [XmlAttribute("speech")]
-        public bool FilterSpeech { get; set; }
-        [DefaultValue(true)]
-        [XmlAttribute("ignoreinscripts")]
-        public bool IgnoreFilteredMessageInScripts { get; set; }
+        [XmlAttribute("text")] public string Text { get; set; }
+
+        [XmlAttribute("sysmessages")] public bool FilterSysMessages { get; set; }
+
+        [XmlAttribute("overhead")] public bool FilterOverhead { get; set; }
+
+        [XmlAttribute("speech")] public bool FilterSpeech { get; set; }
+
+        [XmlAttribute("ignoreinscripts")] public bool IgnoreFilteredMessageInScripts { get; set; }
+
+        public TextFilterEntryModel()
+        {
+        }
+
+        public TextFilterEntryModel(XmlElement element)
+        {
+            Text = element.GetAttribute("text");
+            FilterSpeech = ConvertToBool(element.GetAttribute("speech"), true);
+            FilterOverhead = ConvertToBool(element.GetAttribute("overhead"));
+            FilterSysMessages = ConvertToBool(element.GetAttribute("sysmessages"));
+            IgnoreFilteredMessageInScripts = ConvertToBool(element.GetAttribute("ignoreinscripts"), true);
+        }
+
+        private bool ConvertToBool(string attributeString, bool defaultValue = false)
+        {
+            if (string.IsNullOrWhiteSpace(attributeString))
+                return defaultValue;
+
+            return Convert.ToBoolean(attributeString);
+        }
     }
 
     public static class TextFilterManager
     {
         private static ListBox _filterTextList;
 
-        public static List<string> FilteredText = new List<string>();
+        public static List<TextFilterEntryModel> FilteredText = new List<TextFilterEntryModel>();
 
         public static void SetControls(ListBox filterTextList)
         {
+            filterTextList.DataSource = FilteredText;
+            filterTextList.DisplayMember = nameof(TextFilterEntryModel.Text);
             _filterTextList = filterTextList;
         }
 
-        public static void AddFilter(string filter)
+        public static void AddFilter(TextFilterEntryModel entry)
         {
-            FilteredText.Add(filter);
+            FilteredText.Add(entry);
 
             RedrawList();
         }
 
-        public static void RemoveFilter(string filter)
+        public static void RemoveFilter(int index)
         {
-            FilteredText.Remove(filter);
+            FilteredText.RemoveAt(index);
+
+            RedrawList();
+        }
+
+        public static void UpdateFilter(TextFilterEntryModel entry, int index)
+        {
+            FilteredText[index] = entry;
 
             RedrawList();
         }
 
         public static void Save(XmlTextWriter xml)
         {
-            foreach (var text in FilteredText)
+            var ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+            var serializer = new XmlSerializer(typeof(TextFilterEntryModel));
+            foreach (var entry in FilteredText)
             {
-                xml.WriteStartElement("filter");
-                xml.WriteAttributeString("text", text);
-                xml.WriteEndElement();
+                serializer.Serialize(xml, entry, ns);
             }
         }
 
@@ -87,9 +115,9 @@ namespace Assistant.Core
             if (!Config.GetBool("EnableTextFilter"))
                 return false;
 
-            foreach (string filteredText in FilteredText)
+            foreach (var entry in FilteredText)
             {
-                if (text.IndexOf(filteredText, StringComparison.OrdinalIgnoreCase) != -1)
+                if (text.IndexOf(entry.Text, StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     return true;
                 }
@@ -104,9 +132,9 @@ namespace Assistant.Core
 
             try
             {
-                foreach (XmlElement el in node.GetElementsByTagName("filter"))
+                foreach (var entry in node.ChildNodes.Cast<XmlElement>().Select(el => new TextFilterEntryModel(el)))
                 {
-                    FilteredText.Add(Convert.ToString(el.GetAttribute("text")));
+                    FilteredText.Add(entry);
                 }
 
                 RedrawList();
@@ -124,17 +152,13 @@ namespace Assistant.Core
 
         public static void RedrawList()
         {
-            _filterTextList?.SafeAction(s =>
+            _filterTextList?.SafeAction((lb) =>
             {
-                s.BeginUpdate();
-                s.Items.Clear();
-
-                foreach (string text in FilteredText)
-                {
-                    s.Items.Add(text);
-                }
-
-                s.EndUpdate();
+                lb.BeginUpdate();
+                lb.DataSource = null;
+                lb.DataSource = FilteredText;
+                lb.DisplayMember = nameof(TextFilterEntryModel.Text);
+                lb.EndUpdate();
             });
         }
     }

--- a/Razor/Core/TextFilterManager.cs
+++ b/Razor/Core/TextFilterManager.cs
@@ -30,18 +30,17 @@ using Assistant.UI;
 
 namespace Assistant.Core
 {
-    [XmlType("filter")]
     public class TextFilterEntryModel
     {
-        [XmlAttribute("text")] public string Text { get; set; }
+        public string Text { get; set; }
 
-        [XmlAttribute("sysmessages")] public bool FilterSysMessages { get; set; }
+        public bool FilterSysMessages { get; set; }
 
-        [XmlAttribute("overhead")] public bool FilterOverhead { get; set; }
+        public bool FilterOverhead { get; set; }
 
-        [XmlAttribute("speech")] public bool FilterSpeech { get; set; }
+        public bool FilterSpeech { get; set; }
 
-        [XmlAttribute("ignoreinscripts")] public bool IgnoreFilteredMessageInScripts { get; set; }
+        public bool IgnoreFilteredMessageInScripts { get; set; }
 
         public TextFilterEntryModel()
         {
@@ -101,12 +100,15 @@ namespace Assistant.Core
 
         public static void Save(XmlTextWriter xml)
         {
-            var ns = new XmlSerializerNamespaces();
-            ns.Add("", "");
-            var serializer = new XmlSerializer(typeof(TextFilterEntryModel));
             foreach (var entry in FilteredText)
             {
-                serializer.Serialize(xml, entry, ns);
+                xml.WriteStartElement("filter");
+                xml.WriteAttributeString("text", entry.Text);
+                xml.WriteAttributeString("sysmessages", entry.FilterSysMessages.ToString());
+                xml.WriteAttributeString("overhead", entry.FilterOverhead.ToString());
+                xml.WriteAttributeString("speech", entry.FilterSpeech.ToString());
+                xml.WriteAttributeString("ignoreinscripts", entry.IgnoreFilteredMessageInScripts.ToString());
+                xml.WriteEndElement();
             }
         }
 

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -1998,8 +1998,8 @@ namespace Assistant
                         World.Player.ResetCriminalTimer();
                     }
 
-                    var filterResult = TextFilterManager.IsSysMessageFiltered(text);
-                    if (filterResult != SysMessageFilterResult.HideAndBlock)
+                    var filterResult = TextFilterManager.IsTextFiltered(text, TextFilterType.SysMessage);
+                    if (filterResult != TextFilterResult.HideAndBlock)
                     {
                         // Overhead message override
                         OverheadManager.DisplayOverheadMessage(text);
@@ -2054,7 +2054,7 @@ namespace Assistant
                         return;
                     }
 
-                    if (ser.IsMobile && TextFilterManager.IsSpeechFiltered(text))
+                    if (ser.IsMobile && TextFilterManager.IsTextFiltered(text, TextFilterType.Speech) != TextFilterResult.Allow)
                     {
                         args.Block = true;
                         return;
@@ -2073,10 +2073,11 @@ namespace Assistant
                 // Invalid serial means system message, serial == player means overhead
                 if (ser == World.Player.Serial || !ser.IsValid)
                 {
-                    var filterResult = !ser.IsValid ? TextFilterManager.IsSysMessageFiltered(text) : TextFilterManager.IsOverheadFiltered(text);
-                    if (filterResult != SysMessageFilterResult.HideAndBlock)
+                    var filterType = !ser.IsValid ? TextFilterType.SysMessage : TextFilterType.Overhead;
+                    var filterResult = TextFilterManager.IsTextFiltered(text, filterType);
+                    if (filterResult != TextFilterResult.HideAndBlock)
                         SystemMessages.Add(text);
-                    if (filterResult != SysMessageFilterResult.Allow)
+                    if (filterResult != TextFilterResult.Allow)
                     {
                         args.Block = true;
                         return;

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -1998,14 +1998,11 @@ namespace Assistant
                         World.Player.ResetCriminalTimer();
                     }
 
-                    // Overhead message override
                     var filterResult = TextFilterManager.IsSysMessageFiltered(text);
-                    if(filterResult != SysMessageFilterResult.HideAndBlock)
-                        OverheadManager.DisplayOverheadMessage(text);
-                    if (filterResult != SysMessageFilterResult.Allow)
+                    if (filterResult != SysMessageFilterResult.HideAndBlock)
                     {
-                        args.Block = true;
-                        return;
+                        // Overhead message override
+                        OverheadManager.DisplayOverheadMessage(text);
                     }
                 }
 
@@ -2070,9 +2067,13 @@ namespace Assistant
                     }
                 }
 
-                if (!ser.IsValid || ser == World.Player.Serial || ser.IsItem)
+                if(ser.IsItem)
+                    SystemMessages.Add(text);
+
+                // Invalid serial means system message, serial == player means overhead
+                if (ser == World.Player.Serial || !ser.IsValid)
                 {
-                    var filterResult = TextFilterManager.IsSysMessageFiltered(text);
+                    var filterResult = !ser.IsValid ? TextFilterManager.IsSysMessageFiltered(text) : TextFilterManager.IsOverheadFiltered(text);
                     if (filterResult != SysMessageFilterResult.HideAndBlock)
                         SystemMessages.Add(text);
                     if (filterResult != SysMessageFilterResult.Allow)
@@ -2081,7 +2082,7 @@ namespace Assistant
                         return;
                     }
                 }
-
+                
                 if (Config.GetBool("FilterSystemMessages") && ser == Serial.MinusOne || ser == Serial.Zero)
                 {
                     if (!MessageQueue.Enqueue(ser, null, body, type, hue, font, lang, name, text))

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -1999,7 +1999,14 @@ namespace Assistant
                     }
 
                     // Overhead message override
-                    OverheadManager.DisplayOverheadMessage(text);
+                    var filterResult = TextFilterManager.IsSysMessageFiltered(text);
+                    if(filterResult != SysMessageFilterResult.HideAndBlock)
+                        OverheadManager.DisplayOverheadMessage(text);
+                    if (filterResult != SysMessageFilterResult.Allow)
+                    {
+                        args.Block = true;
+                        return;
+                    }
                 }
 
                 if (Config.GetBool("ShowContainerLabels") && ser.IsItem)
@@ -2050,7 +2057,7 @@ namespace Assistant
                         return;
                     }
 
-                    if (ser.IsMobile && TextFilterManager.IsFiltered(text))
+                    if (ser.IsMobile && TextFilterManager.IsSpeechFiltered(text))
                     {
                         args.Block = true;
                         return;
@@ -2065,7 +2072,14 @@ namespace Assistant
 
                 if (!ser.IsValid || ser == World.Player.Serial || ser.IsItem)
                 {
-                    SystemMessages.Add(text);
+                    var filterResult = TextFilterManager.IsSysMessageFiltered(text);
+                    if (filterResult != SysMessageFilterResult.HideAndBlock)
+                        SystemMessages.Add(text);
+                    if (filterResult != SysMessageFilterResult.Allow)
+                    {
+                        args.Block = true;
+                        return;
+                    }
                 }
 
                 if (Config.GetBool("FilterSystemMessages") && ser == Serial.MinusOne || ser == Serial.Zero)

--- a/Razor/Razor.csproj
+++ b/Razor/Razor.csproj
@@ -464,6 +464,12 @@
     <Compile Include="UI\SplashScreen.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\TextFilterEntry.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\TextFilterEntry.Designer.cs">
+      <DependentUpon>TextFilterEntry.cs</DependentUpon>
+    </Compile>
     <Compile Include="UI\WelcomeForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -575,6 +581,9 @@
     <EmbeddedResource Include="UI\SplashScreen.resx">
       <DependentUpon>SplashScreen.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\TextFilterEntry.resx">
+      <DependentUpon>TextFilterEntry.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\WelcomeForm.resx">
       <DependentUpon>WelcomeForm.cs</DependentUpon>

--- a/Razor/UI/Razor.Designer.cs
+++ b/Razor/UI/Razor.Designer.cs
@@ -3553,9 +3553,9 @@ namespace Assistant
             // 
             // removeFilterText
             // 
-            this.removeFilterText.Location = new System.Drawing.Point(148, 244);
+            this.removeFilterText.Location = new System.Drawing.Point(153, 244);
             this.removeFilterText.Name = "removeFilterText";
-            this.removeFilterText.Size = new System.Drawing.Size(75, 29);
+            this.removeFilterText.Size = new System.Drawing.Size(70, 29);
             this.removeFilterText.TabIndex = 3;
             this.removeFilterText.Text = "Remove";
             this.removeFilterText.UseVisualStyleBackColor = true;
@@ -3563,9 +3563,9 @@ namespace Assistant
             // 
             // addFilterText
             // 
-            this.addFilterText.Location = new System.Drawing.Point(67, 244);
+            this.addFilterText.Location = new System.Drawing.Point(80, 244);
             this.addFilterText.Name = "addFilterText";
-            this.addFilterText.Size = new System.Drawing.Size(75, 29);
+            this.addFilterText.Size = new System.Drawing.Size(68, 29);
             this.addFilterText.TabIndex = 2;
             this.addFilterText.Text = "Add";
             this.addFilterText.UseVisualStyleBackColor = true;
@@ -3575,7 +3575,7 @@ namespace Assistant
             // 
             this.editFilterText.Location = new System.Drawing.Point(5, 244);
             this.editFilterText.Name = "editFilterText";
-            this.editFilterText.Size = new System.Drawing.Size(75, 29);
+            this.editFilterText.Size = new System.Drawing.Size(70, 29);
             this.editFilterText.TabIndex = 1;
             this.editFilterText.Text = "Edit";
             this.editFilterText.UseVisualStyleBackColor = true;

--- a/Razor/UI/Razor.Designer.cs
+++ b/Razor/UI/Razor.Designer.cs
@@ -624,6 +624,7 @@ namespace Assistant
             this.gbFilterText = new System.Windows.Forms.GroupBox();
             this.removeFilterText = new System.Windows.Forms.Button();
             this.addFilterText = new System.Windows.Forms.Button();
+            this.editFilterText = new System.Windows.Forms.Button();
             this.textFilterList = new System.Windows.Forms.ListBox();
             this.enableTextFilter = new System.Windows.Forms.CheckBox();
             this.gbFilterMessages = new System.Windows.Forms.GroupBox();
@@ -3540,6 +3541,7 @@ namespace Assistant
             // 
             this.gbFilterText.Controls.Add(this.removeFilterText);
             this.gbFilterText.Controls.Add(this.addFilterText);
+            this.gbFilterText.Controls.Add(this.editFilterText);
             this.gbFilterText.Controls.Add(this.textFilterList);
             this.gbFilterText.Controls.Add(this.enableTextFilter);
             this.gbFilterText.Location = new System.Drawing.Point(3, 3);
@@ -3554,7 +3556,7 @@ namespace Assistant
             this.removeFilterText.Location = new System.Drawing.Point(148, 244);
             this.removeFilterText.Name = "removeFilterText";
             this.removeFilterText.Size = new System.Drawing.Size(75, 29);
-            this.removeFilterText.TabIndex = 2;
+            this.removeFilterText.TabIndex = 3;
             this.removeFilterText.Text = "Remove";
             this.removeFilterText.UseVisualStyleBackColor = true;
             this.removeFilterText.Click += new System.EventHandler(this.removeFilterText_Click);
@@ -3564,10 +3566,20 @@ namespace Assistant
             this.addFilterText.Location = new System.Drawing.Point(67, 244);
             this.addFilterText.Name = "addFilterText";
             this.addFilterText.Size = new System.Drawing.Size(75, 29);
-            this.addFilterText.TabIndex = 1;
+            this.addFilterText.TabIndex = 2;
             this.addFilterText.Text = "Add";
             this.addFilterText.UseVisualStyleBackColor = true;
             this.addFilterText.Click += new System.EventHandler(this.addFilterText_Click);
+            // 
+            // editFilterText
+            // 
+            this.editFilterText.Location = new System.Drawing.Point(5, 244);
+            this.editFilterText.Name = "editFilterText";
+            this.editFilterText.Size = new System.Drawing.Size(75, 29);
+            this.editFilterText.TabIndex = 1;
+            this.editFilterText.Text = "Add";
+            this.editFilterText.UseVisualStyleBackColor = true;
+            this.editFilterText.Click += new System.EventHandler(this.editFilterText_Click);
             // 
             // textFilterList
             // 
@@ -5540,6 +5552,7 @@ namespace Assistant
         private GroupBox gbFilterText;
         private Button removeFilterText;
         private Button addFilterText;
+        private Button editFilterText;
         private ListBox textFilterList;
         private GroupBox gbFilterMessages;
         private CheckBox filterOverheadMessages;

--- a/Razor/UI/Razor.Designer.cs
+++ b/Razor/UI/Razor.Designer.cs
@@ -3577,7 +3577,7 @@ namespace Assistant
             this.editFilterText.Name = "editFilterText";
             this.editFilterText.Size = new System.Drawing.Size(75, 29);
             this.editFilterText.TabIndex = 1;
-            this.editFilterText.Text = "Add";
+            this.editFilterText.Text = "Edit";
             this.editFilterText.UseVisualStyleBackColor = true;
             this.editFilterText.Click += new System.EventHandler(this.editFilterText_Click);
             // 

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -7285,22 +7285,11 @@ namespace Assistant
         }
         private void addFilterText_Click(object sender, EventArgs e)
         {
-            // if (InputBox.Show(this, "Enter text to filter", "Text Filter"))
-            // {
-            //     string message = InputBox.GetString();
-            //     TextFilterManager.AddFilter(message);
-            // }
             new TextFilterEntry().ShowDialog(Engine.MainWindow);
-
         }
 
         private void editFilterText_Click(object sender, EventArgs e)
         {
-            // if (InputBox.Show(this, "Enter text to filter", "Text Filter"))
-            // {
-            //     string message = InputBox.GetString();
-            //     TextFilterManager.AddFilter(message);
-            // }
             if (textFilterList.SelectedIndex < 0)
                 return;
 

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -7312,7 +7312,7 @@ namespace Assistant
             if (textFilterList.SelectedIndex < 0)
                 return;
 
-            TextFilterManager.RemoveFilter((string) textFilterList.SelectedItem);
+            TextFilterManager.RemoveFilter(textFilterList.SelectedIndex);
         }
 
         private void enableTextFilter_CheckedChanged(object sender, EventArgs e)

--- a/Razor/UI/Razor.cs
+++ b/Razor/UI/Razor.cs
@@ -7285,11 +7285,26 @@ namespace Assistant
         }
         private void addFilterText_Click(object sender, EventArgs e)
         {
-            if (InputBox.Show(this, "Enter text to filter", "Text Filter"))
-            {
-                string message = InputBox.GetString();
-                TextFilterManager.AddFilter(message);
-            }
+            // if (InputBox.Show(this, "Enter text to filter", "Text Filter"))
+            // {
+            //     string message = InputBox.GetString();
+            //     TextFilterManager.AddFilter(message);
+            // }
+            new TextFilterEntry().ShowDialog(Engine.MainWindow);
+
+        }
+
+        private void editFilterText_Click(object sender, EventArgs e)
+        {
+            // if (InputBox.Show(this, "Enter text to filter", "Text Filter"))
+            // {
+            //     string message = InputBox.GetString();
+            //     TextFilterManager.AddFilter(message);
+            // }
+            if (textFilterList.SelectedIndex < 0)
+                return;
+
+            new TextFilterEntry(textFilterList.SelectedItem as TextFilterEntryModel, textFilterList.SelectedIndex).ShowDialog(Engine.MainWindow);
         }
 
         private void removeFilterText_Click(object sender, EventArgs e)

--- a/Razor/UI/Razor.resx
+++ b/Razor/UI/Razor.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="m_NotifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>230, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="m_NotifyIcon.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -163,6 +163,9 @@
         AAD+AAAA/gAAAPwAAAD4AAAA
 </value>
   </data>
+  <metadata name="_objDelayErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="scriptEditor.ServiceColors" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdGYXN0Q29sb3JlZFRleHRCb3gsIFZlcnNpb249Mi4xNi4yMy4w
@@ -181,6 +184,9 @@
         CgAAAAAAAAAAjQABAAH4/////P///woAAAAAAAAAAKQAAQAB9/////z///8KAAAAAAAAAACWAAEACw==
 </value>
   </data>
+  <metadata name="_objDelayErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>63</value>
   </metadata>

--- a/Razor/UI/TextFilterEntry.Designer.cs
+++ b/Razor/UI/TextFilterEntry.Designer.cs
@@ -1,0 +1,149 @@
+﻿
+namespace Assistant.UI
+{
+    partial class TextFilterEntry
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.checkBoxFilterSysMessages = new System.Windows.Forms.CheckBox();
+            this.filterTextBox = new System.Windows.Forms.TextBox();
+            this.enterTextLabel = new System.Windows.Forms.Label();
+            this.checkBoxFilterOverhead = new System.Windows.Forms.CheckBox();
+            this.checkBoxFilterSpeech = new System.Windows.Forms.CheckBox();
+            this.checkBoxIgnoreFilteredInScripts = new System.Windows.Forms.CheckBox();
+            this.cancel = new System.Windows.Forms.Button();
+            this.ok = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // checkBoxFilterSysMessages
+            // 
+            this.checkBoxFilterSysMessages.AutoSize = true;
+            this.checkBoxFilterSysMessages.Location = new System.Drawing.Point(12, 57);
+            this.checkBoxFilterSysMessages.Name = "checkBoxFilterSysMessages";
+            this.checkBoxFilterSysMessages.Size = new System.Drawing.Size(177, 21);
+            this.checkBoxFilterSysMessages.TabIndex = 1;
+            this.checkBoxFilterSysMessages.Text = "Filter system messages";
+            this.checkBoxFilterSysMessages.UseVisualStyleBackColor = true;
+            // 
+            // filterTextBox
+            // 
+            this.filterTextBox.Location = new System.Drawing.Point(12, 29);
+            this.filterTextBox.Name = "filterTextBox";
+            this.filterTextBox.Size = new System.Drawing.Size(355, 22);
+            this.filterTextBox.TabIndex = 0;
+            // 
+            // enterTextLabel
+            // 
+            this.enterTextLabel.AutoSize = true;
+            this.enterTextLabel.Location = new System.Drawing.Point(12, 9);
+            this.enterTextLabel.Name = "enterTextLabel";
+            this.enterTextLabel.Size = new System.Drawing.Size(115, 17);
+            this.enterTextLabel.TabIndex = 2;
+            this.enterTextLabel.Text = "Enter text to filter";
+            this.enterTextLabel.Click += new System.EventHandler(this.label1_Click);
+            // 
+            // checkBoxFilterOverhead
+            // 
+            this.checkBoxFilterOverhead.AutoSize = true;
+            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 84);
+            this.checkBoxFilterOverhead.Name = "checkBoxFilterOverhead";
+            this.checkBoxFilterOverhead.Size = new System.Drawing.Size(125, 21);
+            this.checkBoxFilterOverhead.TabIndex = 2;
+            this.checkBoxFilterOverhead.Text = "Filter overhead";
+            this.checkBoxFilterOverhead.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxFilterSpeech
+            // 
+            this.checkBoxFilterSpeech.AutoSize = true;
+            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 111);
+            this.checkBoxFilterSpeech.Name = "checkBoxFilterSpeech";
+            this.checkBoxFilterSpeech.Size = new System.Drawing.Size(111, 21);
+            this.checkBoxFilterSpeech.TabIndex = 3;
+            this.checkBoxFilterSpeech.Text = "Filter speech";
+            this.checkBoxFilterSpeech.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxIgnoreFilteredInScripts
+            // 
+            this.checkBoxIgnoreFilteredInScripts.AutoSize = true;
+            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 148);
+            this.checkBoxIgnoreFilteredInScripts.Name = "checkBoxIgnoreFilteredInScripts";
+            this.checkBoxIgnoreFilteredInScripts.Size = new System.Drawing.Size(337, 21);
+            this.checkBoxIgnoreFilteredInScripts.TabIndex = 4;
+            this.checkBoxIgnoreFilteredInScripts.Text = "Ignore filtered messages in overhead and scripts";
+            this.checkBoxIgnoreFilteredInScripts.UseVisualStyleBackColor = true;
+            // 
+            // cancel
+            // 
+            this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancel.Location = new System.Drawing.Point(12, 175);
+            this.cancel.Name = "cancel";
+            this.cancel.Size = new System.Drawing.Size(117, 38);
+            this.cancel.TabIndex = 6;
+            this.cancel.Text = "Cancel";
+            this.cancel.Click += new System.EventHandler(this.cancel_Click);
+            // 
+            // ok
+            // 
+            this.ok.Location = new System.Drawing.Point(250, 175);
+            this.ok.Name = "ok";
+            this.ok.Size = new System.Drawing.Size(117, 38);
+            this.ok.TabIndex = 5;
+            this.ok.Text = "Okay";
+            this.ok.Click += new System.EventHandler(this.ok_Click);
+            // 
+            // TextFilterEntry
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(379, 222);
+            this.Controls.Add(this.ok);
+            this.Controls.Add(this.cancel);
+            this.Controls.Add(this.checkBoxIgnoreFilteredInScripts);
+            this.Controls.Add(this.checkBoxFilterSpeech);
+            this.Controls.Add(this.checkBoxFilterOverhead);
+            this.Controls.Add(this.enterTextLabel);
+            this.Controls.Add(this.filterTextBox);
+            this.Controls.Add(this.checkBoxFilterSysMessages);
+            this.Name = "TextFilterEntry";
+            this.Text = "Text filter options";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.CheckBox checkBoxFilterSysMessages;
+        private System.Windows.Forms.TextBox filterTextBox;
+        private System.Windows.Forms.Label enterTextLabel;
+        private System.Windows.Forms.CheckBox checkBoxFilterOverhead;
+        private System.Windows.Forms.CheckBox checkBoxFilterSpeech;
+        private System.Windows.Forms.CheckBox checkBoxIgnoreFilteredInScripts;
+        private System.Windows.Forms.Button cancel;
+        private System.Windows.Forms.Button ok;
+    }
+}

--- a/Razor/UI/TextFilterEntry.Designer.cs
+++ b/Razor/UI/TextFilterEntry.Designer.cs
@@ -42,7 +42,7 @@ namespace Assistant.UI
             // checkBoxFilterSysMessages
             // 
             this.checkBoxFilterSysMessages.AutoSize = true;
-            this.checkBoxFilterSysMessages.Location = new System.Drawing.Point(12, 71);
+            this.checkBoxFilterSysMessages.Location = new System.Drawing.Point(8, 68);
             this.checkBoxFilterSysMessages.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterSysMessages.Name = "checkBoxFilterSysMessages";
             this.checkBoxFilterSysMessages.Size = new System.Drawing.Size(181, 24);
@@ -52,25 +52,25 @@ namespace Assistant.UI
             // 
             // filterTextBox
             // 
-            this.filterTextBox.Location = new System.Drawing.Point(12, 36);
+            this.filterTextBox.Location = new System.Drawing.Point(8, 33);
             this.filterTextBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.filterTextBox.Name = "filterTextBox";
             this.filterTextBox.Size = new System.Drawing.Size(355, 27);
             this.filterTextBox.TabIndex = 0;
+            this.filterTextBox.TextChanged += new System.EventHandler(this.filterTextBox_TextChanged);
             // 
             // enterTextLabel
             // 
             this.enterTextLabel.AutoSize = true;
-            this.enterTextLabel.Location = new System.Drawing.Point(12, 11);
+            this.enterTextLabel.Location = new System.Drawing.Point(5, 9);
             this.enterTextLabel.Name = "enterTextLabel";
             this.enterTextLabel.Size = new System.Drawing.Size(125, 20);
             this.enterTextLabel.TabIndex = 2;
             this.enterTextLabel.Text = "Enter text to filter";
-            this.enterTextLabel.Click += new System.EventHandler(this.label1_Click);
             // 
             // checkBoxFilterOverhead
             // 
-            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 103);
+            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(8, 100);
             this.checkBoxFilterOverhead.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterOverhead.Name = "checkBoxFilterOverhead";
             this.checkBoxFilterOverhead.Size = new System.Drawing.Size(130, 24);
@@ -81,7 +81,7 @@ namespace Assistant.UI
             // checkBoxFilterSpeech
             // 
             this.checkBoxFilterSpeech.AutoSize = true;
-            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 135);
+            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(8, 132);
             this.checkBoxFilterSpeech.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterSpeech.Name = "checkBoxFilterSpeech";
             this.checkBoxFilterSpeech.Size = new System.Drawing.Size(114, 24);
@@ -92,7 +92,7 @@ namespace Assistant.UI
             // checkBoxIgnoreFilteredInScripts
             // 
             this.checkBoxIgnoreFilteredInScripts.AutoSize = true;
-            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 176);
+            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(8, 164);
             this.checkBoxIgnoreFilteredInScripts.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxIgnoreFilteredInScripts.Name = "checkBoxIgnoreFilteredInScripts";
             this.checkBoxIgnoreFilteredInScripts.Size = new System.Drawing.Size(351, 24);
@@ -103,20 +103,20 @@ namespace Assistant.UI
             // cancel
             // 
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(9, 208);
+            this.cancel.Location = new System.Drawing.Point(8, 196);
             this.cancel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.cancel.Name = "cancel";
-            this.cancel.Size = new System.Drawing.Size(117, 41);
+            this.cancel.Size = new System.Drawing.Size(117, 29);
             this.cancel.TabIndex = 6;
             this.cancel.Text = "Cancel";
             this.cancel.Click += new System.EventHandler(this.cancel_Click);
             // 
             // ok
             // 
-            this.ok.Location = new System.Drawing.Point(250, 208);
+            this.ok.Location = new System.Drawing.Point(250, 196);
             this.ok.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.ok.Name = "ok";
-            this.ok.Size = new System.Drawing.Size(117, 41);
+            this.ok.Size = new System.Drawing.Size(117, 29);
             this.ok.TabIndex = 5;
             this.ok.Text = "Okay";
             this.ok.Click += new System.EventHandler(this.ok_Click);
@@ -126,7 +126,7 @@ namespace Assistant.UI
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel;
-            this.ClientSize = new System.Drawing.Size(379, 261);
+            this.ClientSize = new System.Drawing.Size(379, 238);
             this.ControlBox = false;
             this.Controls.Add(this.ok);
             this.Controls.Add(this.cancel);

--- a/Razor/UI/TextFilterEntry.Designer.cs
+++ b/Razor/UI/TextFilterEntry.Designer.cs
@@ -70,8 +70,7 @@ namespace Assistant.UI
             // 
             // checkBoxFilterOverhead
             // 
-            this.checkBoxFilterOverhead.AutoSize = true;
-            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 105);
+            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 103);
             this.checkBoxFilterOverhead.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterOverhead.Name = "checkBoxFilterOverhead";
             this.checkBoxFilterOverhead.Size = new System.Drawing.Size(130, 24);
@@ -82,7 +81,7 @@ namespace Assistant.UI
             // checkBoxFilterSpeech
             // 
             this.checkBoxFilterSpeech.AutoSize = true;
-            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 139);
+            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 135);
             this.checkBoxFilterSpeech.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterSpeech.Name = "checkBoxFilterSpeech";
             this.checkBoxFilterSpeech.Size = new System.Drawing.Size(114, 24);
@@ -93,7 +92,7 @@ namespace Assistant.UI
             // checkBoxIgnoreFilteredInScripts
             // 
             this.checkBoxIgnoreFilteredInScripts.AutoSize = true;
-            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 185);
+            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 176);
             this.checkBoxIgnoreFilteredInScripts.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxIgnoreFilteredInScripts.Name = "checkBoxIgnoreFilteredInScripts";
             this.checkBoxIgnoreFilteredInScripts.Size = new System.Drawing.Size(351, 24);
@@ -104,20 +103,20 @@ namespace Assistant.UI
             // cancel
             // 
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(12, 219);
+            this.cancel.Location = new System.Drawing.Point(9, 208);
             this.cancel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.cancel.Name = "cancel";
-            this.cancel.Size = new System.Drawing.Size(117, 48);
+            this.cancel.Size = new System.Drawing.Size(117, 41);
             this.cancel.TabIndex = 6;
             this.cancel.Text = "Cancel";
             this.cancel.Click += new System.EventHandler(this.cancel_Click);
             // 
             // ok
             // 
-            this.ok.Location = new System.Drawing.Point(250, 219);
+            this.ok.Location = new System.Drawing.Point(250, 208);
             this.ok.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.ok.Name = "ok";
-            this.ok.Size = new System.Drawing.Size(117, 48);
+            this.ok.Size = new System.Drawing.Size(117, 41);
             this.ok.TabIndex = 5;
             this.ok.Text = "Okay";
             this.ok.Click += new System.EventHandler(this.ok_Click);
@@ -127,7 +126,7 @@ namespace Assistant.UI
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancel;
-            this.ClientSize = new System.Drawing.Size(379, 278);
+            this.ClientSize = new System.Drawing.Size(379, 261);
             this.ControlBox = false;
             this.Controls.Add(this.ok);
             this.Controls.Add(this.cancel);

--- a/Razor/UI/TextFilterEntry.Designer.cs
+++ b/Razor/UI/TextFilterEntry.Designer.cs
@@ -42,26 +42,28 @@ namespace Assistant.UI
             // checkBoxFilterSysMessages
             // 
             this.checkBoxFilterSysMessages.AutoSize = true;
-            this.checkBoxFilterSysMessages.Location = new System.Drawing.Point(12, 57);
+            this.checkBoxFilterSysMessages.Location = new System.Drawing.Point(12, 71);
+            this.checkBoxFilterSysMessages.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterSysMessages.Name = "checkBoxFilterSysMessages";
-            this.checkBoxFilterSysMessages.Size = new System.Drawing.Size(177, 21);
+            this.checkBoxFilterSysMessages.Size = new System.Drawing.Size(181, 24);
             this.checkBoxFilterSysMessages.TabIndex = 1;
             this.checkBoxFilterSysMessages.Text = "Filter system messages";
             this.checkBoxFilterSysMessages.UseVisualStyleBackColor = true;
             // 
             // filterTextBox
             // 
-            this.filterTextBox.Location = new System.Drawing.Point(12, 29);
+            this.filterTextBox.Location = new System.Drawing.Point(12, 36);
+            this.filterTextBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.filterTextBox.Name = "filterTextBox";
-            this.filterTextBox.Size = new System.Drawing.Size(355, 22);
+            this.filterTextBox.Size = new System.Drawing.Size(355, 27);
             this.filterTextBox.TabIndex = 0;
             // 
             // enterTextLabel
             // 
             this.enterTextLabel.AutoSize = true;
-            this.enterTextLabel.Location = new System.Drawing.Point(12, 9);
+            this.enterTextLabel.Location = new System.Drawing.Point(12, 11);
             this.enterTextLabel.Name = "enterTextLabel";
-            this.enterTextLabel.Size = new System.Drawing.Size(115, 17);
+            this.enterTextLabel.Size = new System.Drawing.Size(125, 20);
             this.enterTextLabel.TabIndex = 2;
             this.enterTextLabel.Text = "Enter text to filter";
             this.enterTextLabel.Click += new System.EventHandler(this.label1_Click);
@@ -69,9 +71,10 @@ namespace Assistant.UI
             // checkBoxFilterOverhead
             // 
             this.checkBoxFilterOverhead.AutoSize = true;
-            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 84);
+            this.checkBoxFilterOverhead.Location = new System.Drawing.Point(12, 105);
+            this.checkBoxFilterOverhead.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterOverhead.Name = "checkBoxFilterOverhead";
-            this.checkBoxFilterOverhead.Size = new System.Drawing.Size(125, 21);
+            this.checkBoxFilterOverhead.Size = new System.Drawing.Size(130, 24);
             this.checkBoxFilterOverhead.TabIndex = 2;
             this.checkBoxFilterOverhead.Text = "Filter overhead";
             this.checkBoxFilterOverhead.UseVisualStyleBackColor = true;
@@ -79,9 +82,10 @@ namespace Assistant.UI
             // checkBoxFilterSpeech
             // 
             this.checkBoxFilterSpeech.AutoSize = true;
-            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 111);
+            this.checkBoxFilterSpeech.Location = new System.Drawing.Point(12, 139);
+            this.checkBoxFilterSpeech.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxFilterSpeech.Name = "checkBoxFilterSpeech";
-            this.checkBoxFilterSpeech.Size = new System.Drawing.Size(111, 21);
+            this.checkBoxFilterSpeech.Size = new System.Drawing.Size(114, 24);
             this.checkBoxFilterSpeech.TabIndex = 3;
             this.checkBoxFilterSpeech.Text = "Filter speech";
             this.checkBoxFilterSpeech.UseVisualStyleBackColor = true;
@@ -89,9 +93,10 @@ namespace Assistant.UI
             // checkBoxIgnoreFilteredInScripts
             // 
             this.checkBoxIgnoreFilteredInScripts.AutoSize = true;
-            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 148);
+            this.checkBoxIgnoreFilteredInScripts.Location = new System.Drawing.Point(12, 185);
+            this.checkBoxIgnoreFilteredInScripts.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.checkBoxIgnoreFilteredInScripts.Name = "checkBoxIgnoreFilteredInScripts";
-            this.checkBoxIgnoreFilteredInScripts.Size = new System.Drawing.Size(337, 21);
+            this.checkBoxIgnoreFilteredInScripts.Size = new System.Drawing.Size(351, 24);
             this.checkBoxIgnoreFilteredInScripts.TabIndex = 4;
             this.checkBoxIgnoreFilteredInScripts.Text = "Ignore filtered messages in overhead and scripts";
             this.checkBoxIgnoreFilteredInScripts.UseVisualStyleBackColor = true;
@@ -99,27 +104,31 @@ namespace Assistant.UI
             // cancel
             // 
             this.cancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancel.Location = new System.Drawing.Point(12, 175);
+            this.cancel.Location = new System.Drawing.Point(12, 219);
+            this.cancel.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.cancel.Name = "cancel";
-            this.cancel.Size = new System.Drawing.Size(117, 38);
+            this.cancel.Size = new System.Drawing.Size(117, 48);
             this.cancel.TabIndex = 6;
             this.cancel.Text = "Cancel";
             this.cancel.Click += new System.EventHandler(this.cancel_Click);
             // 
             // ok
             // 
-            this.ok.Location = new System.Drawing.Point(250, 175);
+            this.ok.Location = new System.Drawing.Point(250, 219);
+            this.ok.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.ok.Name = "ok";
-            this.ok.Size = new System.Drawing.Size(117, 38);
+            this.ok.Size = new System.Drawing.Size(117, 48);
             this.ok.TabIndex = 5;
             this.ok.Text = "Okay";
             this.ok.Click += new System.EventHandler(this.ok_Click);
             // 
             // TextFilterEntry
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(379, 222);
+            this.CancelButton = this.cancel;
+            this.ClientSize = new System.Drawing.Size(379, 278);
+            this.ControlBox = false;
             this.Controls.Add(this.ok);
             this.Controls.Add(this.cancel);
             this.Controls.Add(this.checkBoxIgnoreFilteredInScripts);
@@ -128,7 +137,12 @@ namespace Assistant.UI
             this.Controls.Add(this.enterTextLabel);
             this.Controls.Add(this.filterTextBox);
             this.Controls.Add(this.checkBoxFilterSysMessages);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "TextFilterEntry";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Text filter options";
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/Razor/UI/TextFilterEntry.cs
+++ b/Razor/UI/TextFilterEntry.cs
@@ -32,6 +32,8 @@ namespace Assistant.UI
             checkBoxFilterOverhead.Checked = _entryModel.FilterOverhead;
             checkBoxFilterSpeech.Checked = _entryModel.FilterSpeech;
             checkBoxIgnoreFilteredInScripts.Checked = _entryModel.IgnoreFilteredMessageInScripts;
+
+            ok.Enabled = !string.IsNullOrWhiteSpace(filterTextBox.Text);
         }
 
         private TextFilterEntryModel GetModelFromConfig()
@@ -45,11 +47,7 @@ namespace Assistant.UI
                 IgnoreFilteredMessageInScripts = checkBoxIgnoreFilteredInScripts.Checked
             };
         }
-
-        private void label1_Click(object sender, EventArgs e)
-        {
-        }
-
+        
         private void cancel_Click(object sender, EventArgs e)
         {
             DialogResult = DialogResult.Cancel;
@@ -70,6 +68,11 @@ namespace Assistant.UI
             }
 
             Close();
+        }
+
+        private void filterTextBox_TextChanged(object sender, EventArgs e)
+        {
+            ok.Enabled = !string.IsNullOrWhiteSpace(filterTextBox.Text);
         }
     }
 }

--- a/Razor/UI/TextFilterEntry.cs
+++ b/Razor/UI/TextFilterEntry.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Windows.Forms;
+using Assistant.Core;
+
+namespace Assistant.UI
+{
+    public partial class TextFilterEntry : Form
+    {
+        private readonly TextFilterEntryModel _entryModel;
+        private readonly int _index;
+        private readonly bool _isNewEntry;
+
+        public TextFilterEntry() : this(new TextFilterEntryModel(), -1)
+        {
+            InitializeComponent();
+            _isNewEntry = true;
+        }
+
+        public TextFilterEntry(TextFilterEntryModel entryModel, int index)
+        {
+            _isNewEntry = false;
+            _entryModel = entryModel;
+            _index = index;
+
+            ApplyEntryModelToControls();
+        }
+
+        private void ApplyEntryModelToControls()
+        {
+            filterTextBox.Text = _entryModel.Text;
+            checkBoxFilterSysMessages.Checked = _entryModel.FilterSysMessages;
+            checkBoxFilterOverhead.Checked = _entryModel.FilterOverhead;
+            checkBoxFilterSpeech.Checked = _entryModel.FilterSpeech;
+            checkBoxIgnoreFilteredInScripts.Checked = _entryModel.IgnoreFilteredMessageInScripts;
+        }
+
+        private void label1_Click(object sender, EventArgs e)
+        {
+        }
+
+        private void cancel_Click(object sender, EventArgs e)
+        {
+        }
+
+        private void ok_Click(object sender, EventArgs e)
+        {
+        }
+    }
+}

--- a/Razor/UI/TextFilterEntry.cs
+++ b/Razor/UI/TextFilterEntry.cs
@@ -12,7 +12,6 @@ namespace Assistant.UI
 
         public TextFilterEntry() : this(new TextFilterEntryModel(), -1)
         {
-            InitializeComponent();
             _isNewEntry = true;
         }
 
@@ -22,6 +21,7 @@ namespace Assistant.UI
             _entryModel = entryModel;
             _index = index;
 
+            InitializeComponent();
             ApplyEntryModelToControls();
         }
 
@@ -34,16 +34,42 @@ namespace Assistant.UI
             checkBoxIgnoreFilteredInScripts.Checked = _entryModel.IgnoreFilteredMessageInScripts;
         }
 
+        private TextFilterEntryModel GetModelFromConfig()
+        {
+            return new TextFilterEntryModel()
+            {
+                Text = filterTextBox.Text,
+                FilterOverhead = checkBoxFilterOverhead.Checked,
+                FilterSpeech = checkBoxFilterSpeech.Checked,
+                FilterSysMessages = checkBoxFilterSysMessages.Checked,
+                IgnoreFilteredMessageInScripts = checkBoxIgnoreFilteredInScripts.Checked
+            };
+        }
+
         private void label1_Click(object sender, EventArgs e)
         {
         }
 
         private void cancel_Click(object sender, EventArgs e)
         {
+            DialogResult = DialogResult.Cancel;
+            Close();
         }
 
         private void ok_Click(object sender, EventArgs e)
         {
+            DialogResult = DialogResult.OK;
+
+            if (_isNewEntry)
+            {
+                TextFilterManager.AddFilter(GetModelFromConfig());
+            }
+            else
+            {
+                TextFilterManager.UpdateFilter(GetModelFromConfig(), _index);
+            }
+
+            Close();
         }
     }
 }

--- a/Razor/UI/TextFilterEntry.resx
+++ b/Razor/UI/TextFilterEntry.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Right now the text filter option under Filters -> Text & Messages only filters speech.

With this PR, players would be able to decide where the text should be filtered on:
* Speech
* Overhead messages from Razor
* System messages

For system messages, they can additionally decide if the filtered messages should still trigger overhead messages and be found via the "insysmsg" script expression.

The change is backwards compatible so players using the speech filter already won't notice any changes.

![image](https://user-images.githubusercontent.com/59250627/161840224-e1d1873f-66c0-4c2e-b77e-2bafeca4b89c.png)
