### PR TITLE
fix: Updates AssistVersion to include "Razor"

### DIFF
--- a/Razor/Network/Packets.cs
+++ b/Razor/Network/Packets.cs
@@ -1795,7 +1795,7 @@ namespace Assistant
         {
             var assistVersion = $"Razor {(typeof(AssistVersion).Assembly.GetName().Version)}";
 
-            EnsureCapacity(9 + assistVersion.Length);
+            EnsureCapacity(3 + assistVersion.Length);
 
             WriteAsciiNull(assistVersion);
         }

--- a/Razor/Network/Packets.cs
+++ b/Razor/Network/Packets.cs
@@ -1793,11 +1793,11 @@ namespace Assistant
         internal AssistVersion()
             : base(0xBE)
         {
-            var version = typeof(AssistVersion).Assembly.GetName().Version.ToString();
+            var assistVersion = $"Razor {(typeof(AssistVersion).Assembly.GetName().Version)}";
 
-            EnsureCapacity(3 + version.Length);
+            EnsureCapacity(9 + assistVersion.Length);
 
-            WriteAsciiNull(version);
+            WriteAsciiNull(assistVersion);
         }
     }
 


### PR DESCRIPTION
Treating 0xBE as a custom packet since UOAssist is no longer used.
Now prepending `Razor` to the assist string.